### PR TITLE
Add department info to auth service

### DIFF
--- a/controllers/userApi_controller.py
+++ b/controllers/userApi_controller.py
@@ -6,6 +6,7 @@ import logging
 
 _logger = logging.getLogger(__name__)
 
+
 class UserApiController(http.Controller):
 
     @http.route("/api/users/me", type="http", auth="user", methods=["POST"], csrf=False)
@@ -31,13 +32,25 @@ class UserApiController(http.Controller):
         if not roles and user.has_group("base.group_user"):
             roles.append("user")
 
+        # Récupère éventuellement l'employé lié à l'utilisateur pour obtenir son département
+        employee = request.env["hr.employee"].search(
+            [("user_id", "=", user.id)], limit=1
+        )
+        department_id = (
+            employee.department_id.id if employee and employee.department_id else None
+        )
+        department_name = (
+            employee.department_id.name if employee and employee.department_id else None
+        )
+
         user_info = {
-        'uid': user.id,
-        'name': user.name,
-        'username': user.login,
-        'roles': roles,
+            "uid": user.id,
+            "name": user.name,
+            "username": user.login,
+            "roles": roles,
+            "department_id": department_id,
+            "department_name": department_name,
         }
-    
+
         # Pour un type='http', il faut retourner une odoo.http.Response
-        return http.Response(json.dumps(user_info), content_type='application/json')
-    
+        return http.Response(json.dumps(user_info), content_type="application/json")


### PR DESCRIPTION
## Summary
- extend user API to return department details
- store department info in login and expose via useAuth

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685303c0f6408329abf9880eed8b24b0