### PR TITLE
Add department stats endpoint

### DIFF
--- a/patrimoine-mtnd/src/pages/director/DirDashboardPage.jsx
+++ b/patrimoine-mtnd/src/pages/director/DirDashboardPage.jsx
@@ -51,9 +51,8 @@ export default function DirDashboardPage() { // Renommage du composant
         // Nouvelle fonction materialService.getMaterialsByDepartment
         const materialsApiResult = await materialService.getMaterialsByDepartment(directorDepartmentId);
         
-        // Récupérer les statistiques pour ce département
-        // materialService.getStatsByDepartment renvoie déjà les stats agrégées.
-        const departmentStatsData = await materialService.fetchStatsByDepartment(directorDepartmentId); 
+        // Récupérer les statistiques pour ce département via la nouvelle route
+        const departmentStatsData = await materialService.fetchStatsByDepartment(directorDepartmentId);
 
         setMaterials(Array.isArray(materialsApiResult) ? materialsApiResult : []); // Assurez-vous que c'est le tableau de données directement
         setStats(departmentStatsData); // statsApiResult est déjà l'objet stats

--- a/patrimoine-mtnd/src/services/apiConfig.js
+++ b/patrimoine-mtnd/src/services/apiConfig.js
@@ -71,6 +71,7 @@ export const apiConfig = {
 
         // --- NOUVEAUX ENDPOINTS POUR LES STATISTIQUES SPÉCIFIQUES ---
         STATS_BY_DEPARTMENT: '/api/patrimoine/stats/by_department',
+        STATS_FOR_DEPARTMENT: (deptId) => `/api/patrimoine/stats/department/${deptId}`,
         // STATS_BY_TYPE: '/api/patrimoine/stats/by_type',
         STATS_BY_DETAILED_CATEGORY: '/api/patrimoine/stats/by_detailed_category',
 

--- a/patrimoine-mtnd/src/services/materialService.js
+++ b/patrimoine-mtnd/src/services/materialService.js
@@ -323,12 +323,19 @@ const getMaterialsByDepartment = async (departmentId) => {
 };
 
 
-const fetchStatsByDepartment = async () => {
+const fetchStatsByDepartment = async (departmentId) => {
   try {
-    const sessionId = localStorage.getItem('odoo_session_id'); if (!sessionId) throw new Error('Session expirée');
-    const response = await get(apiConfig.ENDPOINTS.STATS_BY_DEPARTMENT);
+    const sessionId = localStorage.getItem('odoo_session_id');
+    if (!sessionId) throw new Error('Session expirée');
+    const url = departmentId
+      ? apiConfig.ENDPOINTS.STATS_FOR_DEPARTMENT(departmentId)
+      : apiConfig.ENDPOINTS.STATS_BY_DEPARTMENT;
+    const response = await get(url);
     return response;
-  } catch (error) { console.error('Error fetching stats by department:', error); throw error; }
+  } catch (error) {
+    console.error('Error fetching stats by department:', error);
+    throw error;
+  }
 };
 
 const fetchStatsByType = async () => {


### PR DESCRIPTION
## Summary
- expose stats for one department via `/api/patrimoine/stats/department/<dept_id>`
- support department scoped stats in api configuration and service layer
- load these stats on the director dashboard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685303be20808329832806c237f865aa