### PR TITLE
Implement demande detail fetching

### DIFF
--- a/patrimoine-mtnd/src/services/apiConfig.js
+++ b/patrimoine-mtnd/src/services/apiConfig.js
@@ -62,6 +62,7 @@ export const apiConfig = {
         DEMANDES_LIST: '/api/patrimoine/demandes', // Pour fetchDemandes
         DEMANDES_CREATE: '/api/patrimoine/demandes', // Pour createDemande
         DEMANDES_PROCESS: (demandeId, action) => `/api/patrimoine/demandes/${demandeId}/${action}`, // Pour processDemande
+        DEMANDES_DETAIL: (demandeId) => `/api/patrimoine/demandes/${demandeId}`, // Pour fetchDemandeDetails
 
 
         // --- Endpoints pour les Déclarations de Perte ---

--- a/patrimoine-mtnd/src/services/materialService.js
+++ b/patrimoine-mtnd/src/services/materialService.js
@@ -235,6 +235,19 @@ const fetchDemandes = async () => {
     }
 };
 
+// Pour récupérer le détail d'une demande spécifique
+const fetchDemandeDetails = async (demandeId) => {
+    try {
+        const sessionId = localStorage.getItem('odoo_session_id');
+        if (!sessionId) throw new Error('Session expirée - Veuillez vous reconnecter');
+        const response = await get(apiConfig.ENDPOINTS.DEMANDES_DETAIL(demandeId));
+        return response;
+    } catch (error) {
+        console.error(`Error fetching details for demande ${demandeId}:`, error);
+        throw error;
+    }
+};
+
 // Pour approuver ou rejeter une demande
 const processDemande = async (demandeId, action) => { // action: 'approve' ou 'reject'
     try {
@@ -365,9 +378,10 @@ export default {
   saveMouvement,
   printFicheViePdf,
   getMaterialsByCategory, 
-  getCategoryItems, 
-  getCategoryStats, 
+  getCategoryItems,
+  getCategoryStats,
   fetchDemandes,
+  fetchDemandeDetails,
   processDemande,
   createDemande,
   fetchDeclarationsPerte,


### PR DESCRIPTION
## Summary
- add `DEMANDES_DETAIL` API route
- implement `fetchDemandeDetails` service call
- export new service from `materialService`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852f2df08fc83298b8f6b6e445d8aeb