### PR TITLE
Fix dropdown z-index

### DIFF
--- a/patrimoine-mtnd/src/pages/admin/AdminAjouterMateriel.jsx
+++ b/patrimoine-mtnd/src/pages/admin/AdminAjouterMateriel.jsx
@@ -298,7 +298,7 @@ export default function AdminAjouterMateriel() {
                             <CardHeader className="pb-2">
                                 <CardTitle className="text-lg font-semibold text-gray-800">Catégorisation</CardTitle>
                             </CardHeader>
-                            <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                            <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-6 overflow-visible">
                                 <div className="space-y-2">
                                     <Label className="text-gray-700">Type de matériel</Label>
                                     <Select
@@ -348,7 +348,7 @@ export default function AdminAjouterMateriel() {
                             <CardHeader className="pb-2">
                                 <CardTitle className="text-lg font-semibold text-gray-800">Description</CardTitle>
                             </CardHeader>
-                            <CardContent className="space-y-6">
+                            <CardContent className="space-y-6 overflow-visible">
                                 <div className="space-y-2">
                                     <Label className="text-gray-700">Nom du matériel</Label>
                                     <Input
@@ -407,7 +407,7 @@ export default function AdminAjouterMateriel() {
                             <CardHeader className="pb-2">
                                 <CardTitle className="text-lg font-semibold text-gray-800">Localisation</CardTitle>
                             </CardHeader>
-                            <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                            <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-6 overflow-visible">
                                 <div className="space-y-2">
                                     <Label className="text-gray-700">Localisation actuelle</Label>
                                     <Select
@@ -495,7 +495,7 @@ export default function AdminAjouterMateriel() {
                             <CardHeader className="pb-2">
                                 <CardTitle className="text-lg font-semibold text-gray-800">Documents</CardTitle>
                             </CardHeader>
-                            <CardContent className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                            <CardContent className="grid grid-cols-1 md:grid-cols-3 gap-6 overflow-visible">
                                 <div className="space-y-2">
                                     <Label className="text-gray-700">Image</Label>
                                     <Input
@@ -531,7 +531,7 @@ export default function AdminAjouterMateriel() {
                             <CardHeader className="pb-2">
                                 <CardTitle className="text-lg font-semibold text-gray-800">Détails spécifiques</CardTitle>
                             </CardHeader>
-                            <CardContent>
+                            <CardContent className="overflow-visible">
                                 {selectedSubcategoryId ? (
                                     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                                         {renderDynamicCustomFields()}
@@ -545,7 +545,7 @@ export default function AdminAjouterMateriel() {
                         </Card>
                     </TabsContent>
 
-                    <div className="mt-8 flex justify-end gap-4 sticky bottom-0 bg-white py-4 border-t">
+                    <div className="mt-8 flex justify-end gap-4 sticky bottom-0 z-40 bg-white py-4 border-t">
                         <Button
                             type="button"
                             variant="outline"

--- a/patrimoine-mtnd/src/pages/director/DirDemandeMateriel.jsx
+++ b/patrimoine-mtnd/src/pages/director/DirDemandeMateriel.jsx
@@ -93,7 +93,7 @@ export default function DirDemandeMateriel() {
                     <CardHeader>
                         <CardTitle>Nouvelle Demande de Matériel (Multi-lignes)</CardTitle>
                     </CardHeader>
-                    <CardContent className="space-y-6">
+                    <CardContent className="space-y-6 overflow-visible">
                         
                         {/* --- BOUCLE SUR LES LIGNES --- */}
                         {lignes.map((ligne, index) => (
@@ -104,7 +104,7 @@ export default function DirDemandeMateriel() {
                                         <Label>Matériel</Label>
                                         <Select value={ligne.demande_subcategory_id} onValueChange={val => handleLigneChange(index, 'demande_subcategory_id', val)} required>
                                             <SelectTrigger><SelectValue placeholder="Choisir un matériel..." /></SelectTrigger>
-                                            <SelectContent>{subcategories.map(sc => <SelectItem key={sc.id} value={sc.id}>{sc.category_name} / {sc.name}</SelectItem>)}</SelectContent>
+                                            <SelectContent className="z-50">{subcategories.map(sc => <SelectItem key={sc.id} value={sc.id}>{sc.category_name} / {sc.name}</SelectItem>)}</SelectContent>
                                         </Select>
                                     </div>
                                     <div>
@@ -115,21 +115,21 @@ export default function DirDemandeMateriel() {
                                         <Label>Employé Destinataire</Label>
                                         <Select value={ligne.destinataire_employee_id} onValueChange={val => handleLigneChange(index, 'destinataire_employee_id', val)}>
                                             <SelectTrigger><SelectValue placeholder="Optionnel..." /></SelectTrigger>
-                                            <SelectContent>{employees.map(emp => <SelectItem key={emp.id} value={emp.id}>{emp.name}</SelectItem>)}</SelectContent>
+                                            <SelectContent className="z-50">{employees.map(emp => <SelectItem key={emp.id} value={emp.id}>{emp.name}</SelectItem>)}</SelectContent>
                                         </Select>
                                     </div>
                                     <div>
                                         <Label>Bureau/Localisation</Label>
                                         <Select value={ligne.destinataire_location_id} onValueChange={val => handleLigneChange(index, 'destinataire_location_id', val)}>
                                             <SelectTrigger><SelectValue placeholder="Optionnel..." /></SelectTrigger>
-                                            <SelectContent>{locations.map(loc => <SelectItem key={loc.id} value={loc.id}>{loc.name}</SelectItem>)}</SelectContent>
+                                            <SelectContent className="z-50">{locations.map(loc => <SelectItem key={loc.id} value={loc.id}>{loc.name}</SelectItem>)}</SelectContent>
                                         </Select>
                                     </div>
                                     <div>
                                         <Label>Departement/Direction</Label>
                                         <Select value={ligne.destinataire_department_id} onValueChange={val => handleLigneChange(index, 'destinataire_department_id', val)}>
                                             <SelectTrigger><SelectValue placeholder="Optionnel..." /></SelectTrigger>
-                                            <SelectContent>{departments.map(loc => <SelectItem key={loc.id} value={loc.id}>{loc.name}</SelectItem>)}</SelectContent>
+                                            <SelectContent className="z-50">{departments.map(loc => <SelectItem key={loc.id} value={loc.id}>{loc.name}</SelectItem>)}</SelectContent>
                                         </Select>
                                     </div>
                                 </div>


### PR DESCRIPTION
## Summary
- keep select dropdowns above other content with `z-50`
- prevent clipping by using `overflow-visible` on card content
- raise footer stacking order with `z-40`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852ed006cf08329aee87ae9e2ea7a9e