### PR TITLE
Fix createItem multipart upload

### DIFF
--- a/controllers/asset_controller.py
+++ b/controllers/asset_controller.py
@@ -153,7 +153,7 @@ class PatrimoineAssetController(http.Controller):
             return Response(status=500)
 
     @http.route(
-        "/api/patrimoine/items", auth="user", type="json", methods=["POST"], csrf=False
+        "/api/patrimoine/items", auth="user", type="http", methods=["POST"], csrf=False
     )
     def create_item(self, **post):
         _logger.info("Début de la création d'un item (matériel)")

--- a/patrimoine-mtnd/src/pages/admin/AdminAjouterMateriel.jsx
+++ b/patrimoine-mtnd/src/pages/admin/AdminAjouterMateriel.jsx
@@ -146,8 +146,12 @@ export default function AdminAjouterMateriel() {
         e.preventDefault();
         try {
             const formData = new FormData();
-            
-            Object.entries(assetData).forEach(([key, value]) => {
+
+            // Préparer les données en mappant "etat" vers le champ backend "status"
+            const assetValues = { ...assetData, status: assetData.etat };
+            delete assetValues.etat;
+
+            Object.entries(assetValues).forEach(([key, value]) => {
                 if (['department_id', 'employee_id', 'location_id', 'fournisseur'].includes(key) && value) {
                     formData.append(key, parseInt(value));
                 } else if (key === 'valeur_acquisition' && value) {


### PR DESCRIPTION
## Summary
- map `etat` to `status` before sending asset data
- allow `/api/patrimoine/items` to accept multipart form data

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852ecf55a4c832996bbfdf1c9bdf335