### PR TITLE
Add dynamic stats and category loading

### DIFF
--- a/patrimoine-mtnd/src/pages/admin/AdminMaterialTypes.jsx
+++ b/patrimoine-mtnd/src/pages/admin/AdminMaterialTypes.jsx
@@ -1,51 +1,88 @@
-import { useNavigate } from 'react-router-dom';
-import { Card } from '../../components/ui/card';
+import { useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { Card } from "../../components/ui/card";
+import { StatCard } from "@/components/ui/stat-card";
+import materialService from "@/services/materialService";
 
 export default function AdminMaterialTypes() {
   const navigate = useNavigate();
-  
+  const [counts, setCounts] = useState({});
+
   const materialTypes = [
-    { 
-      id: 1,
-      name: 'Matériel Informatique',
-      image: '/public/images/pc1.jpeg',
-      route: '/admin/informatique'
+    {
+      id: "informatique",
+      name: "Matériel Informatique",
+      image: "/public/images/pc1.jpeg",
+      route: "/admin/informatique",
     },
-    { 
-      id: 2,
-      name: 'Matériel Mobilier', 
-      image: '/public/images/tableBureau1.jpeg',
-      route: '/admin/mobilier'
+    {
+      id: "mobilier",
+      name: "Matériel Mobilier",
+      image: "/public/images/tableBureau1.jpeg",
+      route: "/admin/mobilier",
     },
-    { 
-      id: 3,
-      name: 'Matériel Véhicule',
-      image: '/public/images/voiture1.jpeg',
-      route: '/admin/vehicule'
-    }
+    {
+      id: "vehicule",
+      name: "Matériel Véhicule",
+      image: "/public/images/voiture1.jpeg",
+      route: "/admin/vehicule",
+    },
   ];
 
-  return (
-    <div className="flex justify-center items-center h-screen gap-8">
+  useEffect(() => {
+    const loadStats = async () => {
+      try {
+        const data = await materialService.fetchStatsByType();
+        const statsMap = {};
+        if (Array.isArray(data)) {
+          data.forEach((s) => {
+            statsMap[s.code] = s.count;
+          });
+        }
+        setCounts(statsMap);
+      } catch (error) {
+        console.error("Error loading type stats:", error);
+      }
+    };
+    loadStats();
+  }, []);
 
-      {materialTypes.map((type) => (
-        <Card 
-          key={type.id}
-          className="w-64 h-80 relative overflow-hidden cursor-pointer transition-all hover:scale-105"
-          onClick={() => navigate(type.route)}
-        >
-          <img 
-            src={type.image} 
-            alt={type.name}
-            className="w-full h-full object-cover"
-          />
-          <div className="absolute inset-0 bg-black bg-opacity-0 hover:bg-opacity-50 flex items-center justify-center transition-all">
-            <h2 className="text-white text-2xl font-bold opacity-0 hover:opacity-100 transition-all">
-              {type.name}
-            </h2>
-          </div>
-        </Card>
-      ))}
+  return (
+    <div className="space-y-8">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
+        <StatCard
+          title="Informatique"
+          value={counts.informatique || 0}
+          icon="💻"
+        />
+        <StatCard title="Mobilier" value={counts.mobilier || 0} icon="🪑" />
+        <StatCard
+          title="Roulant"
+          value={counts.vehicule || counts.roulant || 0}
+          icon="🚗"
+        />
+      </div>
+
+      <div className="flex flex-wrap justify-center gap-8">
+        {materialTypes.map((type) => (
+          <Card
+            key={type.id}
+            className="group relative w-64 h-72 overflow-hidden rounded-xl shadow-md cursor-pointer transition-transform duration-300 hover:-translate-y-1 hover:shadow-lg"
+            onClick={() => navigate(type.route)}
+          >
+            <img
+              src={type.image}
+              alt={type.name}
+              className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+            />
+            <div className="absolute inset-0 bg-black/40 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
+              <h2 className="text-white text-xl font-semibold text-center px-2">
+                {type.name}
+              </h2>
+            </div>
+          </Card>
+        ))}
+      </div>
     </div>
   );
 }

--- a/patrimoine-mtnd/src/pages/admin/SubCategoriesPage.jsx
+++ b/patrimoine-mtnd/src/pages/admin/SubCategoriesPage.jsx
@@ -1,43 +1,57 @@
-import { useNavigate, useParams } from 'react-router-dom';
-import { Card } from '../../components/ui/card';
+import { useNavigate, useParams } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { Card } from "../../components/ui/card";
+import materialService from "@/services/materialService";
 
 export default function SubCategoriesPage() {
   const { type } = useParams();
   const navigate = useNavigate();
+  const [subCategories, setSubCategories] = useState([]);
 
-  // Données statiques des sous-catégories par type
-  const subCategories = {
-    informatique: [
-      { id: 1, name: 'Ordinateurs', image: '/public/images/pc2.jpeg' },
-      { id: 2, name: 'Imprimantes', image: '/public/images/imprimante1.jpeg' },
-      { id: 3, name: 'Accessoires', image: '/public/images/pc3.jpeg' }
-    ],
-    mobilier: [
-      { id: 1, name: 'Bureaux', image: '/public/images/tableBureau2.jpeg' },
-      { id: 2, name: 'Chaises', image: '/public/images/fauteuille1.jpeg' },
-      { id: 3, name: 'Armoires', image: '/public/images/tableBureau3.jpeg' }
-    ],
-    vehicule: [
-      { id: 1, name: 'Voitures', image: '/public/images/voiture2.jpeg' },
-      { id: 2, name: 'Motos', image: '/public/images/voiture3.jpeg' }
-    ]
+  useEffect(() => {
+    const loadSubCats = async () => {
+      try {
+        const data = await materialService.fetchSubcategoriesByType(type);
+        setSubCategories(Array.isArray(data) ? data : []);
+      } catch (error) {
+        console.error("Error loading sub categories:", error);
+        setSubCategories([]);
+      }
+    };
+    loadSubCats();
+  }, [type]);
+
+  const imageMap = {
+    ordinateurs: "/public/images/pc2.jpeg",
+    imprimantes: "/public/images/imprimante1.jpeg",
+    accessoires: "/public/images/pc3.jpeg",
+    bureaux: "/public/images/tableBureau2.jpeg",
+    chaises: "/public/images/fauteuille1.jpeg",
+    armoires: "/public/images/tableBureau3.jpeg",
+    voitures: "/public/images/voiture2.jpeg",
+    motos: "/public/images/voiture3.jpeg",
   };
 
   return (
-    <div className="flex justify-center items-center h-screen gap-8">
-      {subCategories[type]?.map((category) => (
-        <Card 
+    <div className="flex flex-wrap justify-center gap-8">
+      {subCategories.map((category) => (
+        <Card
           key={category.id}
-          className="w-64 h-80 relative overflow-hidden cursor-pointer transition-all hover:scale-105"
-          onClick={() => navigate(`/admin/${type}/${category.name.toLowerCase()}`)}
+          className="group relative w-64 h-72 overflow-hidden rounded-xl shadow-md cursor-pointer transition-transform duration-300 hover:-translate-y-1 hover:shadow-lg"
+          onClick={() =>
+            navigate(`/admin/${type}/${category.name.toLowerCase()}`)
+          }
         >
-          <img 
-            src={category.image} 
+          <img
+            src={
+              imageMap[category.name.toLowerCase()] ||
+              "/images/default-material.jpg"
+            }
             alt={category.name}
-            className="w-full h-full object-cover"
+            className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
           />
-          <div className="absolute inset-0 bg-black bg-opacity-0 hover:bg-opacity-50 flex items-center justify-center transition-all">
-            <h2 className="text-white text-2xl font-bold opacity-0 hover:opacity-100 transition-all">
+          <div className="absolute inset-0 bg-black/40 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
+            <h2 className="text-white text-xl font-semibold text-center px-2">
               {category.name}
             </h2>
           </div>

--- a/patrimoine-mtnd/src/services/materialService.js
+++ b/patrimoine-mtnd/src/services/materialService.js
@@ -1,73 +1,100 @@
 // services/materialService.js (COMPLETE AND CONSOLIDATED)
-import { get, post } from './baseService'; 
-import { apiConfig } from './apiConfig';   
+import { get, post } from "./baseService";
+import { apiConfig } from "./apiConfig";
 
 // --- Fonctions de récupération de listes de données ---
 
 const fetchMaterials = async () => {
   try {
-    const sessionId = localStorage.getItem('odoo_session_id');
-    if (!sessionId) { throw new Error('Session expired - Please login again'); }
-    const response = await get(apiConfig.ENDPOINTS.ALL_ASSETS); 
-    return response; 
+    const sessionId = localStorage.getItem("odoo_session_id");
+    if (!sessionId) {
+      throw new Error("Session expired - Please login again");
+    }
+    const response = await get(apiConfig.ENDPOINTS.ALL_ASSETS);
+    return response;
   } catch (error) {
-    console.error('Error fetching materials:', error);
+    console.error("Error fetching materials:", error);
     throw error;
   }
 };
 
 const fetchMaterialDetails = async (id) => {
   try {
-    const sessionId = localStorage.getItem('odoo_session_id');
-    if (!sessionId) { throw new Error('Session expired - Please login again'); }
-    const response = await get(apiConfig.ENDPOINTS.ITEM_DETAILS(id)); 
-    return response; 
+    const sessionId = localStorage.getItem("odoo_session_id");
+    if (!sessionId) {
+      throw new Error("Session expired - Please login again");
+    }
+    const response = await get(apiConfig.ENDPOINTS.ITEM_DETAILS(id));
+    return response;
   } catch (error) {
-    console.error('Error fetching material details:', error);
+    console.error("Error fetching material details:", error);
     throw error;
   }
 };
 
 const fetchLocations = async () => {
-    try {
-        const sessionId = localStorage.getItem('odoo_session_id'); if (!sessionId) throw new Error('Session expirée - Veuillez vous reconnecter');
-        const response = await get(apiConfig.ENDPOINTS.LOCATIONS);
-        return response;
-    } catch (error) { console.error('Error fetching locations:', error); throw error; }
+  try {
+    const sessionId = localStorage.getItem("odoo_session_id");
+    if (!sessionId)
+      throw new Error("Session expirée - Veuillez vous reconnecter");
+    const response = await get(apiConfig.ENDPOINTS.LOCATIONS);
+    return response;
+  } catch (error) {
+    console.error("Error fetching locations:", error);
+    throw error;
+  }
 };
 
 const fetchEmployees = async () => {
-    try {
-        const sessionId = localStorage.getItem('odoo_session_id'); if (!sessionId) throw new Error('Session expirée - Veuillez vous reconnecter');
-        const response = await get(apiConfig.ENDPOINTS.EMPLOYEES);
-        return response;
-    } catch (error) { console.error('Error fetching employees:', error); throw error; }
+  try {
+    const sessionId = localStorage.getItem("odoo_session_id");
+    if (!sessionId)
+      throw new Error("Session expirée - Veuillez vous reconnecter");
+    const response = await get(apiConfig.ENDPOINTS.EMPLOYEES);
+    return response;
+  } catch (error) {
+    console.error("Error fetching employees:", error);
+    throw error;
+  }
 };
 
 const fetchDepartments = async () => {
-    try {
-        const sessionId = localStorage.getItem('odoo_session_id'); if (!sessionId) throw new Error('Session expirée - Veuillez vous reconnecter');
-        const response = await get(apiConfig.ENDPOINTS.DEPARTMENTS);
-        return response;
-    } catch (error) { console.error('Error fetching departments:', error); throw error; }
+  try {
+    const sessionId = localStorage.getItem("odoo_session_id");
+    if (!sessionId)
+      throw new Error("Session expirée - Veuillez vous reconnecter");
+    const response = await get(apiConfig.ENDPOINTS.DEPARTMENTS);
+    return response;
+  } catch (error) {
+    console.error("Error fetching departments:", error);
+    throw error;
+  }
 };
 
 const fetchFournisseurs = async () => {
-    try {
-        const sessionId = localStorage.getItem('odoo_session_id'); if (!sessionId) throw new Error('Session expirée - Veuillez vous reconnecter');
-        const response = await get(apiConfig.ENDPOINTS.FOURNISSEURS);
-        return response;
-    } catch (error) { console.error('Error fetching fournisseur:', error); throw error; }
+  try {
+    const sessionId = localStorage.getItem("odoo_session_id");
+    if (!sessionId)
+      throw new Error("Session expirée - Veuillez vous reconnecter");
+    const response = await get(apiConfig.ENDPOINTS.FOURNISSEURS);
+    return response;
+  } catch (error) {
+    console.error("Error fetching fournisseur:", error);
+    throw error;
+  }
 };
 
-const fetchStats = async () => { // Plus de paramètres ici, c'est pour le GLOBAL
+const fetchStats = async () => {
+  // Plus de paramètres ici, c'est pour le GLOBAL
   try {
-    const sessionId = localStorage.getItem('odoo_session_id'); if (!sessionId) throw new Error('Session expirée - Veuillez vous reconnecter');
+    const sessionId = localStorage.getItem("odoo_session_id");
+    if (!sessionId)
+      throw new Error("Session expirée - Veuillez vous reconnecter");
     const url = apiConfig.ENDPOINTS.GENERAL_STATS; // <-- Utilise la route correcte sans filtre
     const response = await get(url);
     return response; // baseService.get retourne response.data
   } catch (error) {
-    console.error('Error fetching global stats:', error);
+    console.error("Error fetching global stats:", error);
     throw error;
   }
 };
@@ -75,278 +102,401 @@ const fetchStats = async () => { // Plus de paramètres ici, c'est pour le GLOBA
 // Fonctions pour la catégorisation dynamique (pour AdminAjouterMateriel)
 const fetchTypesGeneraux = async () => {
   try {
-    const sessionId = localStorage.getItem('odoo_session_id'); if (!sessionId) throw new Error('Session expirée - Veuillez vous reconnecter');
-    const url = apiConfig.ENDPOINTS.CATEGORIES(); 
+    const sessionId = localStorage.getItem("odoo_session_id");
+    if (!sessionId)
+      throw new Error("Session expirée - Veuillez vous reconnecter");
+    const url = apiConfig.ENDPOINTS.CATEGORIES();
     const response = await get(url);
-    return response.map(cat => ({ id: cat.id, name: cat.name, code: cat.code, type: cat.type }));
-  } catch (error) { console.error('Error fetching general asset types:', error); throw error; }
+    return response.map((cat) => ({
+      id: cat.id,
+      name: cat.name,
+      code: cat.code,
+      type: cat.type,
+    }));
+  } catch (error) {
+    console.error("Error fetching general asset types:", error);
+    throw error;
+  }
 };
 
-const fetchSubcategories = async (categoryId) => { 
+const fetchSubcategories = async (categoryId) => {
   try {
-    const sessionId = localStorage.getItem('odoo_session_id'); if (!sessionId) throw new Error('Session expirée - Veuillez vous reconnecter');
+    const sessionId = localStorage.getItem("odoo_session_id");
+    if (!sessionId)
+      throw new Error("Session expirée - Veuillez vous reconnecter");
     const url = apiConfig.ENDPOINTS.SUBCATEGORIES(categoryId);
     const response = await get(url);
     return response;
-  } catch (error) { console.error('Error fetching subcategories for category ID', categoryId, ':', error); throw error; }
+  } catch (error) {
+    console.error(
+      "Error fetching subcategories for category ID",
+      categoryId,
+      ":",
+      error,
+    );
+    throw error;
+  }
+};
+
+const fetchSubcategoriesByType = async (typeCode) => {
+  try {
+    const categories = await get(
+      `${apiConfig.ENDPOINTS.CATEGORIES()}?type=${typeCode}`,
+    );
+    if (Array.isArray(categories) && categories.length > 0) {
+      return fetchSubcategories(categories[0].id);
+    }
+    return [];
+  } catch (error) {
+    console.error(
+      "Error fetching subcategories for type",
+      typeCode,
+      ":",
+      error,
+    );
+    throw error;
+  }
 };
 
 const fetchCustomFields = async (subcategoryId) => {
   try {
-    const sessionId = localStorage.getItem('odoo_session_id'); if (!sessionId) throw new Error('Session expirée - Veuillez vous reconnecter');
+    const sessionId = localStorage.getItem("odoo_session_id");
+    if (!sessionId)
+      throw new Error("Session expirée - Veuillez vous reconnecter");
     const url = apiConfig.ENDPOINTS.CUSTOM_FIELDS(subcategoryId);
     const response = await get(url);
     return response;
-  } catch (error) { console.error('Error fetching custom fields for subcategory ID', subcategoryId, ':', error); throw error; }
+  } catch (error) {
+    console.error(
+      "Error fetching custom fields for subcategory ID",
+      subcategoryId,
+      ":",
+      error,
+    );
+    throw error;
+  }
 };
-
 
 // --- Fonctions d'opérations sur les Matériels / Mouvements ---
 
-const createItem = async (formData) => { 
+const createItem = async (formData) => {
   try {
-    const sessionId = localStorage.getItem('odoo_session_id');
-    if (!sessionId) { throw new Error('Session expirée - Veuillez vous reconnecter'); }
+    const sessionId = localStorage.getItem("odoo_session_id");
+    if (!sessionId) {
+      throw new Error("Session expirée - Veuillez vous reconnecter");
+    }
 
-    const response = await fetch(apiConfig.ENDPOINTS.CREATE_ITEM, { 
-      method: 'POST',
+    const response = await fetch(apiConfig.ENDPOINTS.CREATE_ITEM, {
+      method: "POST",
       headers: {
-        'X-Openerp-Session-Id': sessionId 
+        "X-Openerp-Session-Id": sessionId,
       },
-      credentials: 'include',
-      body: formData 
+      credentials: "include",
+      body: formData,
     });
 
     if (!response.ok) {
       const errorText = await response.text();
       console.error("Erreur serveur lors de la création d'item:", errorText);
-      throw new Error(`Erreur ${response.status}: ${errorText || 'Erreur inconnue'}`);
+      throw new Error(
+        `Erreur ${response.status}: ${errorText || "Erreur inconnue"}`,
+      );
     }
     return await response.json();
-  } catch (error) { console.error('Error creating item:', error); throw error; }
+  } catch (error) {
+    console.error("Error creating item:", error);
+    throw error;
+  }
 };
 
 const validerMouvement = async (mouvementId) => {
   try {
-    const sessionId = localStorage.getItem('odoo_session_id');
-    if (!sessionId) { throw new Error('Session expirée - Veuillez vous reconnecter'); }
+    const sessionId = localStorage.getItem("odoo_session_id");
+    if (!sessionId) {
+      throw new Error("Session expirée - Veuillez vous reconnecter");
+    }
 
-    const response = await fetch(apiConfig.ENDPOINTS.MOVEMENT_VALIDATE(mouvementId), {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'X-Openerp-Session-Id': sessionId },
-      credentials: 'include', body: JSON.stringify({})
-    });
+    const response = await fetch(
+      apiConfig.ENDPOINTS.MOVEMENT_VALIDATE(mouvementId),
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Openerp-Session-Id": sessionId,
+        },
+        credentials: "include",
+        body: JSON.stringify({}),
+      },
+    );
 
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || 'Erreur lors de la validation du mouvement');
+      throw new Error(
+        errorData.message || "Erreur lors de la validation du mouvement",
+      );
     }
     return await response.json();
-  } catch (error) { console.error('Error validating mouvement:', error); throw error; }
+  } catch (error) {
+    console.error("Error validating mouvement:", error);
+    throw error;
+  }
 };
 
 const saveMouvement = async (data) => {
   try {
-    const sessionId = localStorage.getItem('odoo_session_id');
-    if (!sessionId) { throw new Error('Session expirée - Veuillez vous reconnecter'); }
+    const sessionId = localStorage.getItem("odoo_session_id");
+    if (!sessionId) {
+      throw new Error("Session expirée - Veuillez vous reconnecter");
+    }
 
     const response = await fetch(apiConfig.ENDPOINTS.MOVEMENT_CREATE, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'X-Openerp-Session-Id': sessionId },
-      credentials: 'include', body: JSON.stringify(data)
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Openerp-Session-Id": sessionId,
+      },
+      credentials: "include",
+      body: JSON.stringify(data),
     });
 
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || 'Erreur lors de la sauvegarde du mouvement');
+      throw new Error(
+        errorData.message || "Erreur lors de la sauvegarde du mouvement",
+      );
     }
     return await response.json();
-  } catch (error) { console.error('Error saving mouvement:', error); throw error; }
+  } catch (error) {
+    console.error("Error saving mouvement:", error);
+    throw error;
+  }
 };
 
 const printFicheViePdf = async (assetId) => {
   try {
-    const sessionId = localStorage.getItem('odoo_session_id');
-    if (!sessionId) { throw new Error('Session expired - Please login again'); }
+    const sessionId = localStorage.getItem("odoo_session_id");
+    if (!sessionId) {
+      throw new Error("Session expired - Please login again");
+    }
 
     const requestUrl = apiConfig.ENDPOINTS.PRINT_FICHE_VIE(assetId);
     const response = await fetch(requestUrl, {
-      method: 'GET',
-      headers: { 'X-Openerp-Session-Id': sessionId, 'Accept': 'application/pdf' },
-      credentials: 'include',
+      method: "GET",
+      headers: { "X-Openerp-Session-Id": sessionId, Accept: "application/pdf" },
+      credentials: "include",
     });
 
     if (!response.ok) {
       const errorText = await response.text();
-      throw new Error(`Erreur ${response.status} lors de la génération du PDF: ${errorText}`);
+      throw new Error(
+        `Erreur ${response.status} lors de la génération du PDF: ${errorText}`,
+      );
     }
     const blob = await response.blob();
-    const url = window.URL.createObjectURL(blob); window.open(url, '_blank'); window.URL.revokeObjectURL(url);
-    return { status: 'success' };
-  } catch (error) { console.error('Error printing fiche vie PDF:', error); throw error; }
+    const url = window.URL.createObjectURL(blob);
+    window.open(url, "_blank");
+    window.URL.revokeObjectURL(url);
+    return { status: "success" };
+  } catch (error) {
+    console.error("Error printing fiche vie PDF:", error);
+    throw error;
+  }
 };
-
 
 // Fonctions pour les items par catégorie (utilisées par CategoryItemsPage)
 // C'est cette fonction qui doit appeler la NOUVELLE ROUTE Odoo avec les paramètres dans le chemin.
-const getMaterialsByCategory = (generalType, subcategoryCode) => { 
+const getMaterialsByCategory = (generalType, subcategoryCode) => {
   let url;
   if (subcategoryCode) {
-      url = apiConfig.ENDPOINTS.ASSETS_BY_SUBCATEGORY(subcategoryCode); // Cible /api/patrimoine/assets/category/<code_subcat>
+    url = apiConfig.ENDPOINTS.ASSETS_BY_SUBCATEGORY(subcategoryCode); // Cible /api/patrimoine/assets/category/<code_subcat>
   } else if (generalType) {
-      url = apiConfig.ENDPOINTS.ASSETS_BY_TYPE(generalType); // Cible /api/patrimoine/assets/type/<type_general>
+    url = apiConfig.ENDPOINTS.ASSETS_BY_TYPE(generalType); // Cible /api/patrimoine/assets/type/<type_general>
   } else {
-      url = apiConfig.ENDPOINTS.ALL_ASSETS; // Cible /api/patrimoine/assets (pour tout lister si aucun filtre)
+    url = apiConfig.ENDPOINTS.ALL_ASSETS; // Cible /api/patrimoine/assets (pour tout lister si aucun filtre)
   }
 
   console.log(`Fetching materials (final URL): ${url}`);
-  return get(url); 
+  return get(url);
 };
 
-const getCategoryItems = (generalType, subcategoryCode) => { // Alias de getMaterialsByCategory
+const getCategoryItems = (generalType, subcategoryCode) => {
+  // Alias de getMaterialsByCategory
   return getMaterialsByCategory(generalType, subcategoryCode);
 };
 
 // La fonction getCategoryStats doit aussi utiliser les nouvelles routes par path variable
-const getCategoryStats = (generalType, subcategoryCode) => { 
+const getCategoryStats = (generalType, subcategoryCode) => {
   let url;
   if (subcategoryCode) {
-      url = apiConfig.ENDPOINTS.STATS_BY_SUBCATEGORY(subcategoryCode); // Cible /api/patrimoine/stats/category/<code_subcat>
+    url = apiConfig.ENDPOINTS.STATS_BY_SUBCATEGORY(subcategoryCode); // Cible /api/patrimoine/stats/category/<code_subcat>
   } else if (generalType) {
-      url = `/api/patrimoine/stats/type/${generalType}`; // Cible /api/patrimoine/stats/type/<type_general>
+    url = `/api/patrimoine/stats/type/${generalType}`; // Cible /api/patrimoine/stats/type/<type_general>
   } else {
-      url = apiConfig.ENDPOINTS.GENERAL_STATS; // Cible /api/patrimoine/stats (pour les stats globales)
+    url = apiConfig.ENDPOINTS.GENERAL_STATS; // Cible /api/patrimoine/stats (pour les stats globales)
   }
-  
+
   console.log(`Fetching stats (final URL): ${url}`);
-  return get(url); 
+  return get(url);
 };
 
 // Pour lister toutes les demandes
 const fetchDemandes = async () => {
-    try {
-        const sessionId = localStorage.getItem('odoo_session_id');
-        if (!sessionId) throw new Error('Session expirée - Veuillez vous reconnecter');
-        const response = await get(apiConfig.ENDPOINTS.DEMANDES_LIST); 
-        return response; 
-    } catch (error) {
-        console.error('Error fetching demandes:', error);
-        throw error;
-    }
+  try {
+    const sessionId = localStorage.getItem("odoo_session_id");
+    if (!sessionId)
+      throw new Error("Session expirée - Veuillez vous reconnecter");
+    const response = await get(apiConfig.ENDPOINTS.DEMANDES_LIST);
+    return response;
+  } catch (error) {
+    console.error("Error fetching demandes:", error);
+    throw error;
+  }
 };
 
 // Pour approuver ou rejeter une demande
-const processDemande = async (demandeId, action) => { // action: 'approve' ou 'reject'
-    try {
-        const sessionId = localStorage.getItem('odoo_session_id');
-        if (!sessionId) throw new Error('Session expirée - Veuillez vous reconnecter');
-        const response = await post(apiConfig.ENDPOINTS.DEMANDES_PROCESS(demandeId), { action }); // Envoie l'action dans le body
-        return response; 
-    } catch (error) {
-        console.error(`Error processing demande ${demandeId} with action ${action}:`, error);
-        throw error;
-    }
+const processDemande = async (demandeId, action) => {
+  // action: 'approve' ou 'reject'
+  try {
+    const sessionId = localStorage.getItem("odoo_session_id");
+    if (!sessionId)
+      throw new Error("Session expirée - Veuillez vous reconnecter");
+    const response = await post(
+      apiConfig.ENDPOINTS.DEMANDES_PROCESS(demandeId),
+      { action },
+    ); // Envoie l'action dans le body
+    return response;
+  } catch (error) {
+    console.error(
+      `Error processing demande ${demandeId} with action ${action}:`,
+      error,
+    );
+    throw error;
+  }
 };
 
 // Pour qu'un directeur puisse créer une demande
-const createDemande = async (demandeData) => { // demandeData contiendra les nouveaux champs
-    try {
-        const sessionId = localStorage.getItem('odoo_session_id');
-        if (!sessionId) throw new Error('Session expirée - Veuillez vous reconnecter');
+const createDemande = async (demandeData) => {
+  // demandeData contiendra les nouveaux champs
+  try {
+    const sessionId = localStorage.getItem("odoo_session_id");
+    if (!sessionId)
+      throw new Error("Session expirée - Veuillez vous reconnecter");
 
-        // Note: Le contrôleur Odoo pour create_demande est de type='json'
-        // Donc, nous envoyons un objet JSON
-        const response = await post(apiConfig.ENDPOINTS.DEMANDES_CREATE, demandeData); 
-        return response; 
-    } catch (error) {
-        console.error('Error creating demande:', error);
-        throw error;
-    }
+    // Note: Le contrôleur Odoo pour create_demande est de type='json'
+    // Donc, nous envoyons un objet JSON
+    const response = await post(
+      apiConfig.ENDPOINTS.DEMANDES_CREATE,
+      demandeData,
+    );
+    return response;
+  } catch (error) {
+    console.error("Error creating demande:", error);
+    throw error;
+  }
 };
 
 // --- Fonctions de gestion des Déclarations de Perte ---
 
 // --- Fonction de création d'une Déclaration de Perte ---
-const createPerte = async (perteData) => { // perteData contiendra asset_id et motif
-    try {
-        const sessionId = localStorage.getItem('odoo_session_id');
-        if (!sessionId) throw new Error('Session expirée - Veuillez vous reconnecter');
+const createPerte = async (perteData) => {
+  // perteData contiendra asset_id et motif
+  try {
+    const sessionId = localStorage.getItem("odoo_session_id");
+    if (!sessionId)
+      throw new Error("Session expirée - Veuillez vous reconnecter");
 
-        const response = await post(apiConfig.ENDPOINTS.PERTES_CREATE, perteData); // Nouvelle constante d'endpoint
-        return response; // {status: 'success', perte_id: X, perte_name: 'PERTE/2025/0001'}
-    } catch (error) {
-        console.error('Error creating perte:', error);
-        throw error;
-    }
+    const response = await post(apiConfig.ENDPOINTS.PERTES_CREATE, perteData); // Nouvelle constante d'endpoint
+    return response; // {status: 'success', perte_id: X, perte_name: 'PERTE/2025/0001'}
+  } catch (error) {
+    console.error("Error creating perte:", error);
+    throw error;
+  }
 };
 
 // Pour lister toutes les déclarations de perte
 const fetchDeclarationsPerte = async () => {
-    try {
-        const sessionId = localStorage.getItem('odoo_session_id');
-        if (!sessionId) throw new Error('Session expirée - Veuillez vous reconnecter');
-        const response = await get(apiConfig.ENDPOINTS.PERTES_LIST); // Nouvelle constante d'endpoint
-        return response; // Tableau de déclarations
-    } catch (error) {
-        console.error('Error fetching pertes:', error);
-        throw error;
-    }
+  try {
+    const sessionId = localStorage.getItem("odoo_session_id");
+    if (!sessionId)
+      throw new Error("Session expirée - Veuillez vous reconnecter");
+    const response = await get(apiConfig.ENDPOINTS.PERTES_LIST); // Nouvelle constante d'endpoint
+    return response; // Tableau de déclarations
+  } catch (error) {
+    console.error("Error fetching pertes:", error);
+    throw error;
+  }
 };
 
 // Pour confirmer ou rejeter une déclaration de perte
-const processPerte = async (perteId, action) => { // action: 'confirm' ou 'reject'
-    try {
-        const sessionId = localStorage.getItem('odoo_session_id');
-        if (!sessionId) throw new Error('Session expirée - Veuillez vous reconnecter');
-        const response = await post(apiConfig.ENDPOINTS.PERTES_PROCESS(perteId), { action }); // Envoie l'action dans le body
-        return response; // {status: 'success', new_state: 'confirmed'|'rejected'}
-    } catch (error) {
-        console.error(`Erreur lors du traitement de la perte ${perteId} avec action ${action}:`, error);
-        throw error;
-    }
+const processPerte = async (perteId, action) => {
+  // action: 'confirm' ou 'reject'
+  try {
+    const sessionId = localStorage.getItem("odoo_session_id");
+    if (!sessionId)
+      throw new Error("Session expirée - Veuillez vous reconnecter");
+    const response = await post(apiConfig.ENDPOINTS.PERTES_PROCESS(perteId), {
+      action,
+    }); // Envoie l'action dans le body
+    return response; // {status: 'success', new_state: 'confirmed'|'rejected'}
+  } catch (error) {
+    console.error(
+      `Erreur lors du traitement de la perte ${perteId} avec action ${action}:`,
+      error,
+    );
+    throw error;
+  }
 };
-
 
 // --- NOUVELLE FONCTION : Obtenir les matériels par département ---
 const getMaterialsByDepartment = async (departmentId) => {
-    try {
-        const sessionId = localStorage.getItem('odoo_session_id');
-        if (!sessionId) throw new Error('Session expirée');
-        // Appel de la nouvelle API
-        const url = `/api/patrimoine/assets/department/${departmentId}`; // <-- URL avec l'ID du département dans le chemin
-        const response = await get(url);
-        return response; // Tableau de matériels
-    } catch (error) {
-        console.error('Error fetching materials by department:', error);
-        throw error;
-    }
+  try {
+    const sessionId = localStorage.getItem("odoo_session_id");
+    if (!sessionId) throw new Error("Session expirée");
+    // Appel de la nouvelle API
+    const url = `/api/patrimoine/assets/department/${departmentId}`; // <-- URL avec l'ID du département dans le chemin
+    const response = await get(url);
+    return response; // Tableau de matériels
+  } catch (error) {
+    console.error("Error fetching materials by department:", error);
+    throw error;
+  }
 };
-
 
 const fetchStatsByDepartment = async () => {
   try {
-    const sessionId = localStorage.getItem('odoo_session_id'); if (!sessionId) throw new Error('Session expirée');
+    const sessionId = localStorage.getItem("odoo_session_id");
+    if (!sessionId) throw new Error("Session expirée");
     const response = await get(apiConfig.ENDPOINTS.STATS_BY_DEPARTMENT);
     return response;
-  } catch (error) { console.error('Error fetching stats by department:', error); throw error; }
+  } catch (error) {
+    console.error("Error fetching stats by department:", error);
+    throw error;
+  }
 };
 
 const fetchStatsByType = async () => {
   try {
-    const sessionId = localStorage.getItem('odoo_session_id'); if (!sessionId) throw new Error('Session expirée');
-    const response = await get(apiConfig.ENDPOINTS.STATS_BY_TYPE);
+    const sessionId = localStorage.getItem("odoo_session_id");
+    if (!sessionId) throw new Error("Session expirée");
+    const response = await get("/api/patrimoine/stats/by_type");
     return response;
-  } catch (error) { console.error('Error fetching stats by type:', error); throw error; }
+  } catch (error) {
+    console.error("Error fetching stats by type:", error);
+    throw error;
+  }
 };
 
 const fetchStatsByDetailedCategory = async () => {
   try {
-    const sessionId = localStorage.getItem('odoo_session_id'); if (!sessionId) throw new Error('Session expirée');
+    const sessionId = localStorage.getItem("odoo_session_id");
+    if (!sessionId) throw new Error("Session expirée");
     const response = await get(apiConfig.ENDPOINTS.STATS_BY_DETAILED_CATEGORY);
     return response;
-  } catch (error) { console.error('Error fetching stats by detailed category:', error); throw error; }
+  } catch (error) {
+    console.error("Error fetching stats by detailed category:", error);
+    throw error;
+  }
 };
-
 
 // --- EXPORT DE L'OBJET PAR DÉFAUT QUI CONTIENT TOUTES LES FONCTIONS ---
 export default {
@@ -356,25 +506,26 @@ export default {
   fetchEmployees,
   fetchDepartments,
   fetchFournisseurs,
-  fetchStats, 
-  fetchTypesGeneraux, 
-  fetchSubcategories, 
-  fetchCustomFields,  
+  fetchStats,
+  fetchTypesGeneraux,
+  fetchSubcategories,
+  fetchSubcategoriesByType,
+  fetchCustomFields,
   createItem,
   validerMouvement,
   saveMouvement,
   printFicheViePdf,
-  getMaterialsByCategory, 
-  getCategoryItems, 
-  getCategoryStats, 
+  getMaterialsByCategory,
+  getCategoryItems,
+  getCategoryStats,
   fetchDemandes,
   processDemande,
   createDemande,
   fetchDeclarationsPerte,
   processPerte,
   createPerte,
-  fetchStatsByDepartment, 
-  fetchStatsByType,       
-  fetchStatsByDetailedCategory, 
-  getMaterialsByDepartment
+  fetchStatsByDepartment,
+  fetchStatsByType,
+  fetchStatsByDetailedCategory,
+  getMaterialsByDepartment,
 };


### PR DESCRIPTION
## Summary
- show global material stats on admin types page
- fetch stats from backend
- load subcategories from API instead of static data
- expose helper in material service for subcategory fetching

## Testing
- `npx prettier -w patrimoine-mtnd/src/pages/admin/AdminMaterialTypes.jsx patrimoine-mtnd/src/pages/admin/SubCategoriesPage.jsx patrimoine-mtnd/src/services/materialService.js`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852e44024b88329b45c0ada825c267a