### PR TITLE
Improve admin pages stats and categories

### DIFF
--- a/patrimoine-mtnd/src/pages/admin/AdminMaterialTypes.jsx
+++ b/patrimoine-mtnd/src/pages/admin/AdminMaterialTypes.jsx
@@ -1,8 +1,31 @@
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Card } from '../../components/ui/card';
+import { StatCard } from '../../components/ui/stat-card';
+import materialService from '@/services/materialService';
 
 export default function AdminMaterialTypes() {
   const navigate = useNavigate();
+
+  const [stats, setStats] = useState({});
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      try {
+        const data = await materialService.fetchStatsByType();
+        const parsed = {};
+        if (Array.isArray(data)) {
+          data.forEach((s) => {
+            parsed[s.code] = s.count;
+          });
+        }
+        setStats(parsed);
+      } catch (err) {
+        console.error('Error loading type statistics:', err);
+      }
+    };
+    fetchStats();
+  }, []);
   
   const materialTypes = [
     { 
@@ -25,27 +48,38 @@ export default function AdminMaterialTypes() {
     }
   ];
 
-  return (
-    <div className="flex justify-center items-center h-screen gap-8">
+  const cardClasses = {
+    base: 'group relative w-64 h-80 overflow-hidden rounded-xl shadow-lg hover:shadow-xl transition-all cursor-pointer',
+    image: 'w-full h-full object-cover group-hover:scale-105 transition-transform duration-500',
+    overlay: 'absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity',
+    title: 'absolute bottom-0 left-0 right-0 p-4 text-white text-xl font-semibold'
+  };
 
-      {materialTypes.map((type) => (
-        <Card 
-          key={type.id}
-          className="w-64 h-80 relative overflow-hidden cursor-pointer transition-all hover:scale-105"
-          onClick={() => navigate(type.route)}
-        >
-          <img 
-            src={type.image} 
-            alt={type.name}
-            className="w-full h-full object-cover"
-          />
-          <div className="absolute inset-0 bg-black bg-opacity-0 hover:bg-opacity-50 flex items-center justify-center transition-all">
-            <h2 className="text-white text-2xl font-bold opacity-0 hover:opacity-100 transition-all">
-              {type.name}
-            </h2>
-          </div>
-        </Card>
-      ))}
+  return (
+    <div className="p-8">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
+        <StatCard title="Informatique" value={stats.informatique || 0} icon="💻" />
+        <StatCard title="Mobilier" value={stats.mobilier || 0} icon="🪑" />
+        <StatCard title="Roulant" value={stats.roulant || stats.vehicule || 0} icon="🚗" />
+      </div>
+
+      <div className="flex justify-center items-center gap-8 flex-wrap">
+        {materialTypes.map((type) => (
+          <Card
+            key={type.id}
+            className={cardClasses.base}
+            onClick={() => navigate(type.route)}
+          >
+            <img
+              src={type.image}
+              alt={type.name}
+              className={cardClasses.image}
+            />
+            <div className={cardClasses.overlay} />
+            <h2 className={cardClasses.title}>{type.name}</h2>
+          </Card>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show material counts on admin home
- fetch subcategories dynamically for admin
- enhance card look & feel

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852dade7cf0832997d75340c57bd2a5