### PR TITLE
Fix subcategory requests

### DIFF
--- a/patrimoine-mtnd/src/pages/director/DirDemandeMateriel.jsx
+++ b/patrimoine-mtnd/src/pages/director/DirDemandeMateriel.jsx
@@ -58,7 +58,8 @@ export default function DirDemandeMateriel() {
             try {
                 const [allSubcats, deptsData, locsData, empsData] =
                     await Promise.all([
-                        materialService.fetchSubcategories({ type_code: "" }),
+                        // 0 permet de récupérer toutes les sous-catégories
+                        materialService.fetchSubcategories(0),
                         materialService.fetchDepartments(),
                         materialService.fetchLocations(),
                         materialService.fetchEmployees(),

--- a/patrimoine-mtnd/src/services/materialService.js
+++ b/patrimoine-mtnd/src/services/materialService.js
@@ -20,12 +20,12 @@ const fetchFilteredMaterials = filters => {
 }
 const fetchTypesGeneraux = () =>
     api.get("/api/patrimoine/categories").then(res => res.data)
-const fetchSubcategories = filters => {
-    const queryParams = new URLSearchParams(filters).toString()
-    return api
-        .get(`/api/patrimoine/subcategories?${queryParams}`)
+// Récupère les sous-catégories pour un type général donné
+// Si aucun identifiant n'est fourni (0), toutes les sous-catégories sont renvoyées
+const fetchSubcategories = (categoryId = 0) =>
+    api
+        .get(`/api/patrimoine/subcategories/${categoryId}`)
         .then(res => res.data.data || [])
-}
 const fetchLocations = () =>
     api.get("/api/patrimoine/locations").then(res => res.data)
 const fetchEmployees = () =>


### PR DESCRIPTION
## Summary
- update `fetchSubcategories` to accept a category id and use REST endpoint
- adjust director request form to load all subcategories via id 0

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867dcca487c832981508b5c06456d71