### PR TITLE
Use query params for subcategory fetch

### DIFF
--- a/patrimoine-mtnd/src/pages/admin/AdminAjouterMateriel.jsx
+++ b/patrimoine-mtnd/src/pages/admin/AdminAjouterMateriel.jsx
@@ -108,7 +108,7 @@ export default function AdminAjouterMateriel() {
                         materialService.fetchEmployees(),
                         materialService.fetchDepartments(),
                         materialService.fetchFournisseurs(),
-                        materialService.fetchSubcategories(0), // 0 pour toutes les récupérer
+                        materialService.fetchSubcategories({ type_code: "" }), // filtre vide pour toutes les récupérer
                     ])
                 setGeneralAssetTypes(types)
                 setLocations(locs)

--- a/patrimoine-mtnd/src/pages/admin/SubCategoriesPage.jsx
+++ b/patrimoine-mtnd/src/pages/admin/SubCategoriesPage.jsx
@@ -23,9 +23,9 @@ export default function SubCategoriesPage() {
 
                 if (generalCategory) {
                     setGeneralTypeName(generalCategory.name)
-                    const data = await materialService.fetchSubcategories(
-                        generalCategory.id
-                    )
+                    const data = await materialService.fetchSubcategories({
+                        category_id: generalCategory.id,
+                    })
                     if (!data || data.error)
                         throw new Error(data?.error || "Erreur chargement")
                     setSubCategories(data)

--- a/patrimoine-mtnd/src/pages/director/DirDemandeMateriel.jsx
+++ b/patrimoine-mtnd/src/pages/director/DirDemandeMateriel.jsx
@@ -58,8 +58,8 @@ export default function DirDemandeMateriel() {
             try {
                 const [allSubcats, deptsData, locsData, empsData] =
                     await Promise.all([
-                        // 0 permet de récupérer toutes les sous-catégories
-                        materialService.fetchSubcategories(0),
+                        // filtre vide pour récupérer toutes les sous-catégories
+                        materialService.fetchSubcategories({ type_code: "" }),
                         materialService.fetchDepartments(),
                         materialService.fetchLocations(),
                         materialService.fetchEmployees(),

--- a/patrimoine-mtnd/src/services/materialService.js
+++ b/patrimoine-mtnd/src/services/materialService.js
@@ -22,10 +22,12 @@ const fetchTypesGeneraux = () =>
     api.get("/api/patrimoine/categories").then(res => res.data)
 // Récupère les sous-catégories pour un type général donné
 // Si aucun identifiant n'est fourni (0), toutes les sous-catégories sont renvoyées
-const fetchSubcategories = (categoryId = 0) =>
-    api
-        .get(`/api/patrimoine/subcategories/${categoryId}`)
+const fetchSubcategories = filters => {
+    const query = new URLSearchParams(filters).toString()
+    return api
+        .get(`/api/patrimoine/subcategories?${query}`)
         .then(res => res.data.data || [])
+}
 const fetchLocations = () =>
     api.get("/api/patrimoine/locations").then(res => res.data)
 const fetchEmployees = () =>


### PR DESCRIPTION
## Summary
- revert subcategory API to accept query parameters
- adjust admin, director, and material pages to send filter objects
- demonstrate npm test/vitest attempts

## Testing
- `npm test` *(fails: Missing script)*
- `npx vitest` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6867ee1fee70832994a11f2da4a95c5d