### PR TITLE
Fix asset form numeric field prefill

### DIFF
--- a/patrimoine-mtnd/src/pages/admin/AdminAjouterMateriel.jsx
+++ b/patrimoine-mtnd/src/pages/admin/AdminAjouterMateriel.jsx
@@ -138,18 +138,18 @@ export default function AdminAjouterMateriel() {
                     console.log("Type général trouvé :", generalType)
 
                     setAssetData({
-                        name: materialToEdit.name || "",
+                        name: materialToEdit.name ?? "",
                         date_acquisition: materialToEdit.acquisitionDate
                             ? new Date(materialToEdit.acquisitionDate)
                                   .toISOString()
                                   .split("T")[0]
                             : "",
-                        valeur_acquisition: materialToEdit.value || "",
-                        etat: materialToEdit.status || "stock",
-                        department_id: materialToEdit.department_id || "",
-                        employee_id: materialToEdit.assignedTo_id || "",
-                        location_id: materialToEdit.location_id || "",
-                        fournisseur: materialToEdit.fournisseur_id || "",
+                        valeur_acquisition: materialToEdit.value ?? "",
+                        etat: materialToEdit.status ?? "stock",
+                        department_id: materialToEdit.department_id ?? "",
+                        employee_id: materialToEdit.assignedTo_id ?? "",
+                        location_id: materialToEdit.location_id ?? "",
+                        fournisseur: materialToEdit.fournisseur_id ?? "",
                     })
 
                     // On pré-sélectionne les catégories


### PR DESCRIPTION
## Summary
- ensure numeric values from `fetchMaterialDetails` are not replaced by empty strings

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6867f22887bc8329a5d18828cd606bff