### PR TITLE
Update subcategory API calls

### DIFF
--- a/patrimoine-mtnd/src/pages/admin/AdminAjouterMateriel.jsx
+++ b/patrimoine-mtnd/src/pages/admin/AdminAjouterMateriel.jsx
@@ -108,7 +108,7 @@ export default function AdminAjouterMateriel() {
                         materialService.fetchEmployees(),
                         materialService.fetchDepartments(),
                         materialService.fetchFournisseurs(),
-                        materialService.fetchSubcategories({ type_code: "" }), // filtre vide pour toutes les récupérer
+                        materialService.fetchSubcategories(0), // 0 pour récupérer toutes les sous-catégories
                     ])
                 setGeneralAssetTypes(types)
                 setLocations(locs)

--- a/patrimoine-mtnd/src/pages/admin/SubCategoriesPage.jsx
+++ b/patrimoine-mtnd/src/pages/admin/SubCategoriesPage.jsx
@@ -23,9 +23,9 @@ export default function SubCategoriesPage() {
 
                 if (generalCategory) {
                     setGeneralTypeName(generalCategory.name)
-                    const data = await materialService.fetchSubcategories({
-                        category_id: generalCategory.id,
-                    })
+                    const data = await materialService.fetchSubcategories(
+                        generalCategory.id
+                    )
                     if (!data || data.error)
                         throw new Error(data?.error || "Erreur chargement")
                     setSubCategories(data)

--- a/patrimoine-mtnd/src/pages/director/DirDemandeMateriel.jsx
+++ b/patrimoine-mtnd/src/pages/director/DirDemandeMateriel.jsx
@@ -58,8 +58,8 @@ export default function DirDemandeMateriel() {
             try {
                 const [allSubcats, deptsData, locsData, empsData] =
                     await Promise.all([
-                        // filtre vide pour récupérer toutes les sous-catégories
-                        materialService.fetchSubcategories({ type_code: "" }),
+                        // 0 pour récupérer toutes les sous-catégories
+                        materialService.fetchSubcategories(0),
                         materialService.fetchDepartments(),
                         materialService.fetchLocations(),
                         materialService.fetchEmployees(),

--- a/patrimoine-mtnd/src/services/materialService.js
+++ b/patrimoine-mtnd/src/services/materialService.js
@@ -22,12 +22,11 @@ const fetchFilteredMaterials = filters => {
 }
 const fetchTypesGeneraux = () =>
     api.get("/api/patrimoine/categories").then(res => res.data)
-// Récupère les sous-catégories pour un type général donné
+// Récupère les sous-catégories pour la catégorie spécifiée
 // Si aucun identifiant n'est fourni (0), toutes les sous-catégories sont renvoyées
-const fetchSubcategories = filters => {
-    const query = new URLSearchParams(filters).toString()
+const fetchSubcategories = (categoryId = 0) => {
     return api
-        .get(`/api/patrimoine/subcategories?${query}`)
+        .get(`/api/patrimoine/subcategories/${categoryId}`)
         .then(res => res.data.data || [])
 }
 const fetchLocations = () =>


### PR DESCRIPTION
## Summary
- update `fetchSubcategories` to use `/api/patrimoine/subcategories/<categoryId>`
- adapt components to pass an id instead of a filter object

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867f970af888329926c9eb859520d3d