### PR TITLE
Fix type lookup by code in edit form

### DIFF
--- a/patrimoine-mtnd/src/pages/admin/AdminAjouterMateriel.jsx
+++ b/patrimoine-mtnd/src/pages/admin/AdminAjouterMateriel.jsx
@@ -133,7 +133,7 @@ export default function AdminAjouterMateriel() {
                     )
 
                     const generalType = types.find(
-                        t => t.name === materialToEdit.category
+                        t => t.code === materialToEdit.type
                     )
                     console.log("Type général trouvé :", generalType)
 


### PR DESCRIPTION
## Summary
- find the material type by code instead of name when editing an item

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867f97163248329aff4c26eb2b7ed64