### PR TITLE
Fix dropdown loading for material edit

### DIFF
--- a/patrimoine-mtnd/src/pages/admin/AdminAjouterMateriel.jsx
+++ b/patrimoine-mtnd/src/pages/admin/AdminAjouterMateriel.jsx
@@ -99,6 +99,7 @@ export default function AdminAjouterMateriel() {
         console.log("Mode édition détecté ?", isEditMode)
         console.log("ID à modifier :", materialIdToEdit)
         const loadDependencies = async () => {
+            setIsLoading(true)
             try {
                 // On charge toutes les listes nécessaires pour les menus déroulants
                 const [types, locs, emps, depts, fours, subcats] =
@@ -133,7 +134,9 @@ export default function AdminAjouterMateriel() {
                     )
 
                     const generalType = types.find(
-                        t => t.code === materialToEdit.type
+                        t =>
+                            t.code === materialToEdit.type ||
+                            t.name === materialToEdit.category
                     )
                     console.log("Type général trouvé :", generalType)
 
@@ -165,10 +168,10 @@ export default function AdminAjouterMateriel() {
                         )
                     }
                 } else { console.log("Mode création détecté (pas d'ID)."); }
+                setIsLoading(false)
             } catch (error) {
                 console.error("Erreur chargement des données:", error)
                 toast.error("Impossible de charger les données nécessaires.")
-            } finally {
                 setIsLoading(false)
             }
         }


### PR DESCRIPTION
## Summary
- prevent form render before dropdown data loads
- fallback when resolving type from API to handle code or name
- update loading state handling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6868002474f48329ae65a16e5118837f