### PR TITLE
Fix route order for admin paths

### DIFF
--- a/patrimoine-mtnd/src/App.jsx
+++ b/patrimoine-mtnd/src/App.jsx
@@ -73,22 +73,6 @@ function AppContent() {
               />
 
               <Route
-                  path="/admin/:type"
-                  element={
-                      <ProtectedRoute roles={[ROLES.ADMIN]}>
-                          <SubCategoriesPage />
-                      </ProtectedRoute>
-                  }
-              />
-              <Route
-                  path="/admin/:type/:category"
-                  element={
-                      <ProtectedRoute roles={[ROLES.ADMIN]}>
-                          <CategoryItemsPage />
-                      </ProtectedRoute>
-                  }
-              />
-              <Route
                   path="/admin/ajouter"
                   element={
                       <ProtectedRoute roles={[ROLES.ADMIN]}>
@@ -125,6 +109,22 @@ function AppContent() {
                   element={
                       <ProtectedRoute roles={[ROLES.ADMIN]}>
                           <AdminDeclarationsPerte />
+                      </ProtectedRoute>
+                  }
+              />
+              <Route
+                  path="/admin/:type/:category"
+                  element={
+                      <ProtectedRoute roles={[ROLES.ADMIN]}>
+                          <CategoryItemsPage />
+                      </ProtectedRoute>
+                  }
+              />
+              <Route
+                  path="/admin/:type"
+                  element={
+                      <ProtectedRoute roles={[ROLES.ADMIN]}>
+                          <SubCategoriesPage />
                       </ProtectedRoute>
                   }
               />


### PR DESCRIPTION
## Summary
- adjust admin routes so static paths come before `/admin/:type`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686808aff94483298f2a06dc81e2e99b