### PR TITLE
Replace alert with toast in SubCategoriesPage

### DIFF
--- a/patrimoine-mtnd/src/pages/admin/SubCategoriesPage.jsx
+++ b/patrimoine-mtnd/src/pages/admin/SubCategoriesPage.jsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router-dom"
 import materialService from "@/services/materialService"
 import { ArrowLeft } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { toast } from "react-hot-toast"
 
 export default function SubCategoriesPage() {
     const { type } = useParams()
@@ -32,7 +33,7 @@ export default function SubCategoriesPage() {
                 } else throw new Error(`Type "${type}" introuvable.`)
             } catch (error) {
                 console.error("Erreur:", error)
-                alert(`Erreur: ${error.message}`)
+                toast.error(`Erreur: ${error.message}`)
                 navigate("/admin")
             } finally {
                 setIsLoading(false)


### PR DESCRIPTION
## Summary
- import `toast` from `react-hot-toast`
- use `toast.error` instead of `alert` when failing to load subcategories

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686808b268c08329a7dcbfae5c8fb11b