### PR TITLE
Use environment-based API URL for images

### DIFF
--- a/patrimoine-mtnd/src/components/PerteDetailModal.jsx
+++ b/patrimoine-mtnd/src/components/PerteDetailModal.jsx
@@ -4,6 +4,7 @@ import React from "react"
 import { X } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { API_BASE_URL } from "@/config/api"
 
 export default function PerteDetailModal({ perte, onClose }) {
     if (!perte) return null
@@ -92,7 +93,7 @@ export default function PerteDetailModal({ perte, onClose }) {
                             {perte.rapport_police ? "Oui" : "Non"}
                             {perte.document_url && (
                                 <a
-                                    href={`http://localhost:8069${perte.document_url}`}
+                                    href={`${API_BASE_URL}${perte.document_url}`}
                                     target="_blank"
                                     rel="noopener noreferrer"
                                     className="ml-4 text-blue-600 hover:underline"

--- a/patrimoine-mtnd/src/config/api.js
+++ b/patrimoine-mtnd/src/config/api.js
@@ -1,0 +1,1 @@
+export const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8069';

--- a/patrimoine-mtnd/src/pages/admin/AdminAjouterMateriel.jsx
+++ b/patrimoine-mtnd/src/pages/admin/AdminAjouterMateriel.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react"
 import { useNavigate, useLocation } from "react-router-dom" // CORRECTION: On utilise useLocation
 import materialService from "@/services/materialService"
+import { API_BASE_URL } from "@/config/api"
 import { toast } from "react-hot-toast"
 import Select from "react-select"
 import makeAnimated from "react-select/animated"
@@ -164,7 +165,7 @@ export default function AdminAjouterMateriel() {
                     setSpecificData(materialToEdit.details || {})
                     if (materialToEdit.image) {
                         setImagePreview(
-                            `http://localhost:8069${materialToEdit.image}`
+                            `${API_BASE_URL}${materialToEdit.image}`
                         )
                     }
                 } else { console.log("Mode création détecté (pas d'ID)."); }

--- a/patrimoine-mtnd/src/pages/admin/MaterialDetailPage.jsx
+++ b/patrimoine-mtnd/src/pages/admin/MaterialDetailPage.jsx
@@ -15,6 +15,7 @@ import { Separator } from "@/components/ui/separator"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import materialService from "@/services/materialService"
 import AppSidebar from "@/components/app-sidebar"
+import { API_BASE_URL } from "@/config/api"
 import {
     Edit,
     FileText,
@@ -279,7 +280,7 @@ export default function MaterialDetailPage() {
                                         {material.image && (
                                             <div className="w-full md:w-1/3 flex justify-center">
                                                 <img
-                                                    src={`http://localhost:8069${material.image}`}
+                                                    src={`${API_BASE_URL}${material.image}`}
                                                     alt={material.name}
                                                     className="rounded-lg border shadow-sm max-h-96 w-full object-contain"
                                                 />

--- a/patrimoine-mtnd/src/pages/agents/AgentDashboardPage.jsx
+++ b/patrimoine-mtnd/src/pages/agents/AgentDashboardPage.jsx
@@ -14,6 +14,7 @@ import { Badge } from "@/components/ui/badge"
 import materialService from "@/services/materialService"
 import { useAuth } from "@/context/AuthContext"
 import { StatCard } from "@/components/ui/stat-card"
+import { API_BASE_URL } from "@/config/api"
 import { Input } from "@/components/ui/input"
 import {
     Search,
@@ -182,7 +183,7 @@ export default function AgentDashboardPage() {
                                 <img
                                     src={
                                         material.image
-                                            ? `http://localhost:8069${material.image}`
+                                            ? `${API_BASE_URL}${material.image}`
                                             : "/images/default-material.jpg"
                                     }
                                     alt={material.name}

--- a/patrimoine-mtnd/src/pages/director/DirDashboardPage.jsx
+++ b/patrimoine-mtnd/src/pages/director/DirDashboardPage.jsx
@@ -7,6 +7,7 @@ import { StatCard } from "@/components/ui/stat-card"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
+import { API_BASE_URL } from "@/config/api"
 import {
     Search,
     PlusCircle,
@@ -188,7 +189,7 @@ export default function DirDashboardPage() {
                                 <img
                                     src={
                                         material.image
-                                            ? `http://localhost:8069${material.image}`
+                                            ? `${API_BASE_URL}${material.image}`
                                             : "/images/default-material.jpg"
                                     }
                                     alt={material.name}

--- a/patrimoine-mtnd/src/services/demandeService.js
+++ b/patrimoine-mtnd/src/services/demandeService.js
@@ -1,10 +1,9 @@
 import axios from 'axios'
-
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8069'
+import { API_BASE_URL } from '@/config/api'
 
 export const fetchDepartments = async () => {
   try {
-    const response = await axios.get(`${API_URL}/api/hr/departments`)
+    const response = await axios.get(`${API_BASE_URL}/api/hr/departments`)
     return response.data
   } catch (error) {
     console.error('Error fetching departments:', error)
@@ -14,7 +13,7 @@ export const fetchDepartments = async () => {
 
 export const fetchLocations = async () => {
   try {
-    const response = await axios.get(`${API_URL}/api/patrimoine/locations`)
+    const response = await axios.get(`${API_BASE_URL}/api/patrimoine/locations`)
     return response.data
   } catch (error) {
     console.error('Error fetching locations:', error)
@@ -24,7 +23,7 @@ export const fetchLocations = async () => {
 
 export const fetchEmployees = async () => {
   try {
-    const response = await axios.get(`${API_URL}/api/hr/employees`)
+    const response = await axios.get(`${API_BASE_URL}/api/hr/employees`)
     return response.data
   } catch (error) {
     console.error('Error fetching employees:', error)
@@ -34,7 +33,7 @@ export const fetchEmployees = async () => {
 
 export const fetchDemandes = async () => {
   try {
-    const response = await axios.get(`${API_URL}/api/patrimoine/demandes`)
+    const response = await axios.get(`${API_BASE_URL}/api/patrimoine/demandes`)
     return response.data
   } catch (error) {
     console.error('Error fetching demandes:', error)
@@ -44,7 +43,7 @@ export const fetchDemandes = async () => {
 
 export const createDemande = async (data) => {
   try {
-    const response = await axios.post(`${API_URL}/api/patrimoine/demandes`, data)
+    const response = await axios.post(`${API_BASE_URL}/api/patrimoine/demandes`, data)
     return response.data
   } catch (error) {
     console.error('Error creating demande:', error)
@@ -55,7 +54,7 @@ export const createDemande = async (data) => {
 export const declareEntretien = async (demandeId, data) => {
   try {
     const response = await axios.post(
-      `${API_URL}/api/patrimoine/demandes/${demandeId}/entretien`, 
+      `${API_BASE_URL}/api/patrimoine/demandes/${demandeId}/entretien`,
       data
     )
     return response.data


### PR DESCRIPTION
## Summary
- centralize API base url in `src/config/api.js`
- use `API_BASE_URL` when building image links across UI pages
- update `demandeService` to reference the shared constant

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' because of offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_686808b5015c8329a7361d73ea22c4a9