### PR TITLE
Add alias route for subcategory page

### DIFF
--- a/patrimoine-mtnd/src/App.jsx
+++ b/patrimoine-mtnd/src/App.jsx
@@ -112,6 +112,15 @@ function AppContent() {
                       </ProtectedRoute>
                   }
               />
+              {/* Alias pour éviter l'erreur 404 lorsque l'on utilise l'ancien chemin */}
+              <Route
+                  path="/subCategoriesPage/:type"
+                  element={
+                      <ProtectedRoute roles={[ROLES.ADMIN]}>
+                          <SubCategoriesPage />
+                      </ProtectedRoute>
+                  }
+              />
               <Route
                   path="/admin/:type/:category"
                   element={


### PR DESCRIPTION
## Summary
- add `/subCategoriesPage/:type` alias so legacy links still work

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68685aa91bb08329946d10b1b7afb9a9