### PR TITLE
Fix API access for public calls

### DIFF
--- a/controllers/asset_controller.py
+++ b/controllers/asset_controller.py
@@ -64,7 +64,7 @@ def handle_api_errors(f):
 
 
 class PatrimoineAssetController(http.Controller):
-    @http.route("/api/patrimoine/categories", auth="user", type="http", methods=["GET"])
+    @http.route("/api/patrimoine/categories", auth="public", type="http", methods=["GET"], csrf=False)
     def list_categories(self, **kw):
         try:
             domain = []
@@ -152,9 +152,10 @@ class PatrimoineAssetController(http.Controller):
 
     @http.route(
         "/api/patrimoine/subcategories/<int:category_id>",
-        auth="user",
+        auth="public",
         type="http",
         methods=["GET"],
+        csrf=False,
     )
     @handle_api_errors
     def list_subcategories(self, category_id, **kw):


### PR DESCRIPTION
## Summary
- expose categories and subcategories endpoints without authentication

## Testing
- `python -m py_compile controllers/asset_controller.py`


------
https://chatgpt.com/codex/tasks/task_e_686862215bac8329b6e0a932ba14869a