### PR TITLE
Remove leftover lines from SubCategoriesPage

### DIFF
--- a/patrimoine-mtnd/src/pages/admin/SubCategoriesPage.jsx
+++ b/patrimoine-mtnd/src/pages/admin/SubCategoriesPage.jsx
@@ -26,13 +26,7 @@ export default function SubCategoriesPage() {
 
         if (generalCategory) {
           setGeneralTypeName(generalCategory.name);
-            "[SubCategoriesPage] Fetching subcategories for category id",
-            generalCategory.id,
-          );
           const allSubcats = await materialService.fetchSubcategories(0); // 0 => all
-            "[SubCategoriesPage] Received subcategories:",
-            allSubcats,
-          );
           const data = allSubcats.filter(
             (sc) => sc.category_id === generalCategory.id,
           );


### PR DESCRIPTION
## Summary
- clean up SubCategoriesPage.jsx by removing stray lines from previous console logging

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6869a28b0f108329960440cc6661210d