### PR TITLE
Implement basic chat models and APIs

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -30,6 +30,7 @@
     'controllers': [
         'controllers/userApi_controller.py',
         'controllers/asset_controller.py',
+        'controllers/chat_controller.py',
     ],
     'installable': True,
     'application': True,

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -1,2 +1,3 @@
 from . import asset_controller
 from . import userApi_controller
+from . import chat_controller

--- a/controllers/chat_controller.py
+++ b/controllers/chat_controller.py
@@ -1,0 +1,52 @@
+from odoo import http
+from odoo.http import request
+
+class ChatController(http.Controller):
+    @http.route('/api/chat/conversations', auth='user', type='json', methods=['GET'])
+    def list_conversations(self, **kwargs):
+        user = request.env.user
+        conversations = request.env['chat.conversation'].sudo().search([
+            ('participant_ids', 'in', user.id)
+        ])
+        result = []
+        for conv in conversations:
+            last_message = conv.message_ids and conv.message_ids[-1] or False
+            result.append({
+                'id': conv.id,
+                'name': conv.name or ', '.join(conv.participant_ids.mapped('name')),
+                'last_message': last_message.body if last_message else False,
+                'last_date': last_message.date if last_message else False,
+            })
+        return result
+
+    @http.route('/api/chat/conversations/<int:conv_id>/messages', auth='user', type='json', methods=['GET'])
+    def get_messages(self, conv_id, **kwargs):
+        conv = request.env['chat.conversation'].sudo().browse(conv_id)
+        if not conv.exists() or request.env.user.id not in conv.participant_ids.ids:
+            return []
+        messages = conv.message_ids.sorted('date')
+        return [
+            {
+                'id': m.id,
+                'sender_id': m.sender_id.id,
+                'sender_name': m.sender_id.name,
+                'body': m.body,
+                'date': m.date,
+            }
+            for m in messages
+        ]
+
+    @http.route('/api/chat/conversations/<int:conv_id>/messages', auth='user', type='json', methods=['POST'], csrf=False)
+    def post_message(self, conv_id, content, **kwargs):
+        conv = request.env['chat.conversation'].sudo().browse(conv_id)
+        if not conv.exists() or request.env.user.id not in conv.participant_ids.ids:
+            return {'error': 'Conversation not found'}
+        msg = request.env['chat.message'].sudo().create({
+            'conversation_id': conv.id,
+            'sender_id': request.env.user.id,
+            'body': content,
+        })
+        return {
+            'id': msg.id,
+            'date': msg.date,
+        }

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -8,3 +8,5 @@ from . import fiche_vie
 from . import demande_materiel
 from . import demande_materiel_ligne
 from . import pertes
+
+from . import chat

--- a/models/chat.py
+++ b/models/chat.py
@@ -1,0 +1,31 @@
+from odoo import models, fields
+
+class ChatConversation(models.Model):
+    _name = "chat.conversation"
+    _description = "Conversation"
+
+    name = fields.Char(string="Nom")
+    participant_ids = fields.Many2many(
+        "res.users", string="Participants"
+    )
+    message_ids = fields.One2many(
+        "chat.message", "conversation_id", string="Messages"
+    )
+
+
+class ChatMessage(models.Model):
+    _name = "chat.message"
+    _description = "Message"
+    _order = "date asc"
+
+    conversation_id = fields.Many2one(
+        "chat.conversation",
+        string="Conversation",
+        required=True,
+        ondelete="cascade",
+    )
+    sender_id = fields.Many2one(
+        "res.users", string="Exp\xC3\xA9diteur", required=True, default=lambda self: self.env.user
+    )
+    body = fields.Text(string="Contenu", required=True)
+    date = fields.Datetime(string="Date", default=fields.Datetime.now)

--- a/security/ir.model.access.csv
+++ b/security/ir.model.access.csv
@@ -36,3 +36,9 @@ access_asset_agent,access.asset.agent,model_patrimoine_asset,gestion_patrimoine.
 access_mouvement_agent,access.mouvement.agent,model_patrimoine_mouvement,gestion_patrimoine.group_patrimoine_agent,1,0,0,0
 access_entretien_agent,access.entretien.agent,model_patrimoine_entretien,gestion_patrimoine.group_patrimoine_agent,1,0,0,0
 access_perte_agent,access.perte.agent,model_patrimoine_perte,gestion_patrimoine.group_patrimoine_agent,1,1,0,0
+access_chat_conversation_admin,access.chat.conversation.admin,model_chat_conversation,gestion_patrimoine.group_patrimoine_admin,1,1,1,1
+access_chat_conversation_director,access.chat.conversation.director,model_chat_conversation,gestion_patrimoine.group_patrimoine_director,1,1,1,1
+access_chat_conversation_agent,access.chat.conversation.agent,model_chat_conversation,gestion_patrimoine.group_patrimoine_agent,1,1,1,0
+access_chat_message_admin,access.chat.message.admin,model_chat_message,gestion_patrimoine.group_patrimoine_admin,1,1,1,1
+access_chat_message_director,access.chat.message.director,model_chat_message,gestion_patrimoine.group_patrimoine_director,1,1,1,1
+access_chat_message_agent,access.chat.message.agent,model_chat_message,gestion_patrimoine.group_patrimoine_agent,1,1,1,0


### PR DESCRIPTION
## Summary
- add `chat.conversation` and `chat.message` models
- create chat controller with list, fetch and post APIs
- expose new controller in manifest and module init
- grant access rights for chat models

## Testing
- `python -m py_compile models/chat.py controllers/chat_controller.py`

------
https://chatgpt.com/codex/tasks/task_e_6869a9ca26908329ae3956da8a89186d