### PR TITLE
Add chat service and unit tests

### DIFF
--- a/patrimoine-mtnd/README.md
+++ b/patrimoine-mtnd/README.md
@@ -22,3 +22,12 @@ npm run build
 
 Assurez-vous qu'un serveur Odoo configuré avec le module **intranet_MTND** tourne sur le même hôte afin que les requêtes API soient résolues correctement.
 
+
+## Exécution des tests
+
+Les tests Jest sont situés dans `src/tests`. Après installation des dépendances, lancez :
+
+```bash
+npm test
+```
+

--- a/patrimoine-mtnd/package.json
+++ b/patrimoine-mtnd/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint . --ext js,jsx,ts,tsx --fix",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "test": "jest"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.4",
@@ -51,6 +52,7 @@
     "postcss": "^8.4.35",
     "prettier": "^3.2.5",
     "tailwindcss": "^3.4.1",
-    "vite": "^5.1.4"
+    "vite": "^5.1.4",
+    "jest": "^29.7.0"
   }
 }

--- a/patrimoine-mtnd/src/services/chatService.js
+++ b/patrimoine-mtnd/src/services/chatService.js
@@ -1,0 +1,16 @@
+import api from './apiConfig'
+
+export const createConversation = async (participants) => {
+  const response = await api.post('/api/chat/conversations', { participants })
+  return response.data
+}
+
+export const sendMessage = async (conversationId, content) => {
+  const response = await api.post(`/api/chat/conversations/${conversationId}/messages`, { content })
+  return response.data
+}
+
+export default {
+  createConversation,
+  sendMessage
+}

--- a/patrimoine-mtnd/src/tests/integration/chatService.test.js
+++ b/patrimoine-mtnd/src/tests/integration/chatService.test.js
@@ -1,0 +1,30 @@
+import chatService from '../../services/chatService'
+
+describe('Chat Service Integration Tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('should create conversation successfully', async () => {
+    const mockResponse = { status: 'success', id: 1 }
+    chatService.createConversation = jest.fn().mockResolvedValue(mockResponse)
+
+    const participants = [1, 2]
+    const result = await chatService.createConversation(participants)
+
+    expect(chatService.createConversation).toHaveBeenCalledWith(participants)
+    expect(result).toEqual(mockResponse)
+  })
+
+  test('should send message successfully', async () => {
+    const mockResponse = { status: 'success', message_id: 10 }
+    chatService.sendMessage = jest.fn().mockResolvedValue(mockResponse)
+
+    const conversationId = 1
+    const content = 'Hello world'
+    const result = await chatService.sendMessage(conversationId, content)
+
+    expect(chatService.sendMessage).toHaveBeenCalledWith(conversationId, content)
+    expect(result).toEqual(mockResponse)
+  })
+})

--- a/patrimoine-mtnd/src/tests/integration/hrService.test.js
+++ b/patrimoine-mtnd/src/tests/integration/hrService.test.js
@@ -1,0 +1,30 @@
+import axios from 'axios'
+import { fetchEmployees, fetchDepartments } from '../../services/demandeService'
+
+jest.mock('axios')
+
+describe('HR Service fetches', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('fetchEmployees should return employees list', async () => {
+    const mockData = [{ id: 1, name: 'John' }]
+    axios.get.mockResolvedValue({ data: mockData })
+
+    const result = await fetchEmployees()
+
+    expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('/api/hr/employees'))
+    expect(result).toEqual(mockData)
+  })
+
+  test('fetchDepartments should return departments list', async () => {
+    const mockData = [{ id: 2, name: 'IT' }]
+    axios.get.mockResolvedValue({ data: mockData })
+
+    const result = await fetchDepartments()
+
+    expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('/api/hr/departments'))
+    expect(result).toEqual(mockData)
+  })
+})


### PR DESCRIPTION
## Summary
- add chat service for creating conversations and sending messages
- add Jest tests for chat service
- add Jest tests for HR API functions
- document how to run tests in README
- expose `npm test` script and Jest dependency

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869a9d263ac83298ab570950957e975