### PR TITLE
Fix starting chat conversation

### DIFF
--- a/patrimoine-mtnd/src/pages/chat/ChatPage.jsx
+++ b/patrimoine-mtnd/src/pages/chat/ChatPage.jsx
@@ -38,7 +38,7 @@ export default function ChatPage() {
   useOdooBus(handleNewMessage)
 
   const startConversation = async emp => {
-    const conv = await chatService.startConversation(emp.id)
+    const conv = await chatService.createConversation([emp.id])
     setConversations(prev => {
       if (prev.find(c => c.id === conv.id)) return prev
       return [...prev, conv]


### PR DESCRIPTION
## Summary
- adjust ChatPage to call `createConversation` when starting a new chat

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869af10eb488329a8907aff52525fcd