### PR TITLE
Add intranet post views and menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ un espace de chat interne et un mur de posts pour partager les annonces du minis
 1. Copier le dossier `intranet_MTND` dans le répertoire `custom-addons`
 2. Redémarrer Odoo
 3. Installer le module via l'interface administrateur
+4. Dans le menu **Gestion du Patrimoine**, ouvrez l'élément **Posts** pour gérer les annonces internes.
 
 ## Dépendances
 - Odoo 17

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -17,6 +17,7 @@
         "views/asset_views.xml",
         "views/entretien_views.xml",
         "views/fiche_vie_views.xml",
+        "views/intranet_post_views.xml",
         "views/menu.xml",
         "views/mouvement_views.xml",
         "views/perte_views.xml",

--- a/views/intranet_post_views.xml
+++ b/views/intranet_post_views.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_intranet_post_tree" model="ir.ui.view">
+        <field name="name">intranet.post.tree</field>
+        <field name="model">intranet.post</field>
+        <field name="arch" type="xml">
+            <tree string="Publications">
+                <field name="name"/>
+                <field name="user_id"/>
+                <field name="department_id" optional="show"/>
+                <field name="create_date"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_intranet_post_form" model="ir.ui.view">
+        <field name="name">intranet.post.form</field>
+        <field name="model">intranet.post</field>
+        <field name="arch" type="xml">
+            <form string="Publication">
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="user_id" readonly="1"/>
+                        <field name="department_id"/>
+                        <field name="active"/>
+                    </group>
+                    <group>
+                        <field name="body" colspan="4" nolabel="1" widget="html"/>
+                    </group>
+                    <group>
+                        <field name="image" widget="image" class="oe_avatar"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_intranet_post" model="ir.actions.act_window">
+        <field name="name">Posts</field>
+        <field name="res_model">intranet.post</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+</odoo>

--- a/views/menu.xml
+++ b/views/menu.xml
@@ -8,6 +8,7 @@
     <menuitem id="menu_patrimoine_assets" name="Biens" parent="menu_patrimoine_root" sequence="10"/>
     <menuitem id="menu_patrimoine_mouvements" name="Mouvements" parent="menu_patrimoine_root" sequence="20"/>
     <menuitem id="menu_patrimoine_entretiens" name="Entretiens" parent="menu_patrimoine_root" sequence="30"/>
+    <menuitem id="menu_intranet_posts" name="Posts" parent="menu_patrimoine_root" action="action_intranet_post" sequence="40"/>
     <menuitem id="menu_patrimoine_config" name="Configuration" parent="menu_patrimoine_root" sequence="100"/>
 </odoo>
 


### PR DESCRIPTION
## Summary
- create list/form views and action for intranet.post
- link new Posts menu in main menu
- include intranet_post_views.xml in module manifest
- document how to access Posts page

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6869c64fa5988329a1bcec9aac9d94ed