### PR TITLE
Update test instructions

### DIFF
--- a/patrimoine-mtnd/README.md
+++ b/patrimoine-mtnd/README.md
@@ -25,7 +25,17 @@ Assurez-vous qu'un serveur Odoo configuré avec le module **intranet_MTND** tour
 
 ## Exécution des tests
 
-Les tests Jest sont situés dans `src/tests`. Après installation des dépendances, lancez :
+Les tests Jest sont situés dans `src/tests`.
+
+1. Installez les dépendances du projet avant d'exécuter les tests :
+
+```bash
+npm install
+```
+
+   Cette étape requiert un accès Internet ou un registre local déjà configuré afin de récupérer les dépendances de développement définies dans `package.json`, telles que **Jest**.
+
+2. Lancez ensuite les tests :
 
 ```bash
 npm test


### PR DESCRIPTION
## Summary
- clarify that `npm install` must run before `npm test`
- note that installing dev dependencies requires internet or a local npm registry

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869c650c95c8329ac1b4e00d49478f5