### PR TITLE
Handle existing admin group

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,8 @@ Contact: [http://www.mtnd.gov.ci](http://www.mtnd.gov.ci)
 ## Licence
 LGPL-3
 
+## Migration
+Lors de la migration depuis une version antérieure, le groupe « Administrateur Patrimoine » peut déjà exister mais avec un identifiant XML différent.
+Le script d'initialisation recherche donc ce groupe et, s'il le trouve, associe
+l'identifiant `gestion_patrimoine.group_patrimoine_admin` au groupe existant au lieu d'en créer un nouveau.
+

--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,3 @@
 from . import models
 from . import controllers
+from .hooks import pre_init_hook

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -6,6 +6,7 @@
     'author': 'Coulibaly Yadjiman',
     'website': 'http://www.example.com',
     'depends': ['base', 'hr', 'stock', 'account', 'fleet', 'bus', 'mail'],
+    'pre_init_hook': 'pre_init_hook',
     "data": [
         "data/sequence.xml",
         "data/cron.xml",

--- a/hooks.py
+++ b/hooks.py
@@ -1,0 +1,31 @@
+from odoo import api, SUPERUSER_ID
+
+
+def pre_init_hook(cr):
+    """Link existing admin group by name if present."""
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    category = None
+    try:
+        category = env.ref('gestion_patrimoine.module_category_patrimoine', raise_if_not_found=False)
+    except Exception:
+        category = None
+    if not category:
+        category = env['ir.module.category'].search([('name', '=', 'Patrimoine')], limit=1)
+    domain = [('name', '=', 'Administrateur Patrimoine')]
+    if category:
+        domain.append(('category_id', '=', category.id))
+    group = env['res.groups'].search(domain, limit=1)
+    if group:
+        if not env['ir.model.data'].search([
+            ('model', '=', 'res.groups'),
+            ('module', '=', 'gestion_patrimoine'),
+            ('name', '=', 'group_patrimoine_admin')
+        ]):
+            env['ir.model.data'].create({
+                'name': 'group_patrimoine_admin',
+                'model': 'res.groups',
+                'module': 'gestion_patrimoine',
+                'res_id': group.id,
+                'noupdate': True,
+            })
+    # If not found, data loading will create the group normally


### PR DESCRIPTION
## Summary
- link existing `Administrateur Patrimoine` group during module init
- expose the hook in module init
- document migration considerations

## Testing
- `npm test --prefix patrimoine-mtnd` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a65c668cc8329b9512e65f5c836d3