### PR TITLE
Add post-init hook for admin group

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,6 @@ LGPL-3
 
 ## Migration
 Lors de la migration depuis une version antérieure, le groupe « Administrateur Patrimoine » peut déjà exister mais avec un identifiant XML différent.
-Le script d'initialisation recherche donc ce groupe et, s'il le trouve, associe
-l'identifiant `gestion_patrimoine.group_patrimoine_admin` au groupe existant au lieu d'en créer un nouveau.
+Les hooks d'initialisation recherchent donc ce groupe et, s'il est trouvé, lui
+associent l'identifiant `gestion_patrimoine.group_patrimoine_admin` au lieu d'en créer un nouveau. Ce processus s'exécute aussi bien lors d'une nouvelle installation que lors d'une mise à jour du module.
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,3 @@
 from . import models
 from . import controllers
-from .hooks import pre_init_hook
+from .hooks import pre_init_hook, post_init_hook

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -7,6 +7,7 @@
     'website': 'http://www.example.com',
     'depends': ['base', 'hr', 'stock', 'account', 'fleet', 'bus', 'mail'],
     'pre_init_hook': 'pre_init_hook',
+    'post_init_hook': 'post_init_hook',
     "data": [
         "data/sequence.xml",
         "data/cron.xml",

--- a/hooks.py
+++ b/hooks.py
@@ -1,9 +1,8 @@
 from odoo import api, SUPERUSER_ID
 
 
-def pre_init_hook(cr):
-    """Link existing admin group by name if present."""
-    env = api.Environment(cr, SUPERUSER_ID, {})
+def _link_admin_group(env):
+    """Ensure XML ID for the admin group exists."""
     category = None
     try:
         category = env.ref('gestion_patrimoine.module_category_patrimoine', raise_if_not_found=False)
@@ -15,17 +14,29 @@ def pre_init_hook(cr):
     if category:
         domain.append(('category_id', '=', category.id))
     group = env['res.groups'].search(domain, limit=1)
-    if group:
-        if not env['ir.model.data'].search([
-            ('model', '=', 'res.groups'),
-            ('module', '=', 'gestion_patrimoine'),
-            ('name', '=', 'group_patrimoine_admin')
-        ]):
-            env['ir.model.data'].create({
-                'name': 'group_patrimoine_admin',
-                'model': 'res.groups',
-                'module': 'gestion_patrimoine',
-                'res_id': group.id,
-                'noupdate': True,
-            })
+    if group and not env['ir.model.data'].search([
+        ('model', '=', 'res.groups'),
+        ('module', '=', 'gestion_patrimoine'),
+        ('name', '=', 'group_patrimoine_admin')
+    ]):
+        env['ir.model.data'].create({
+            'name': 'group_patrimoine_admin',
+            'model': 'res.groups',
+            'module': 'gestion_patrimoine',
+            'res_id': group.id,
+            'noupdate': True,
+        })
+
+
+def pre_init_hook(cr):
+    """Link existing admin group by name if present."""
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    _link_admin_group(env)
     # If not found, data loading will create the group normally
+
+
+def post_init_hook(cr, registry):
+    """Ensure XML ID exists when upgrading the module."""
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    _link_admin_group(env)
+


### PR DESCRIPTION
## Summary
- add a `post_init_hook` to create/link the patrimoine admin group on upgrade
- export `post_init_hook` from `__init__.py`
- register it in `__manifest__.py`
- document hook execution in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a6b22e808832989615c41732e97f8