### PR TITLE
Fix README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ un espace de chat interne et un mur de posts pour partager les annonces du minis
 - Agent : consultation et déclaration limitée
 
 ## Installation
-1. Copier le dossier `intranet_MTND` dans le répertoire `custom-addons`
+1. Copier le dossier `gestion_patrimoine` dans le répertoire `custom-addons`
 2. Redémarrer Odoo
 3. Installer le module via l'interface administrateur
 4. Dans le menu **Gestion du Patrimoine**, ouvrez l'élément **Posts** pour gérer les annonces internes.

--- a/patrimoine-mtnd/README.md
+++ b/patrimoine-mtnd/README.md
@@ -20,7 +20,7 @@ npm run dev
 npm run build
 ```
 
-Assurez-vous qu'un serveur Odoo configuré avec le module **intranet_MTND** tourne sur le même hôte afin que les requêtes API soient résolues correctement.
+Assurez-vous qu'un serveur Odoo configuré avec le module **gestion_patrimoine** tourne sur le même hôte afin que les requêtes API soient résolues correctement.
 
 
 ## Exécution des tests


### PR DESCRIPTION
## Summary
- reference the `gestion_patrimoine` directory in installation docs
- keep frontend instructions consistent with backend module name

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a6b241ec4832985cbffa32a647e82