### PR TITLE
Add integration tests for updated chat API

### DIFF
--- a/patrimoine-mtnd/src/services/chatService.js
+++ b/patrimoine-mtnd/src/services/chatService.js
@@ -3,20 +3,33 @@ import api from './apiConfig'
 // On récupère toutes les fonctions des deux versions
 
 // Pour récupérer toutes les conversations
+// The API now wraps payloads inside a `data` key
+const unwrap = res => (res.data && res.data.data ? res.data.data : res.data)
+
 const fetchConversations = () =>
-  api.get('/api/chat/conversations').then(res => res.data);
+  api.get('/api/chat/conversations').then(unwrap)
 
 // Pour récupérer les messages d'une conversation spécifique
-const fetchMessages = (conversationId) =>
-  api.get(`/api/chat/conversations/${conversationId}/messages`).then(res => res.data);
+const fetchMessages = conversationId =>
+  api
+    .get(`/api/chat/conversations/${conversationId}/messages`)
+    .then(res => {
+      const messages = unwrap(res) || []
+      // Ensure every message carries its conversation id
+      return messages.map(m => ({ conversation_id: conversationId, ...m }))
+    })
 
 // Pour envoyer un message
 const sendMessage = (conversationId, content) =>
-  api.post(`/api/chat/conversations/${conversationId}/messages`, { content }).then(res => res.data);
+  api
+    .post(`/api/chat/conversations/${conversationId}/messages`, { content })
+    .then(res => ({ conversation_id: conversationId, ...unwrap(res) }))
 
 // Pour démarrer une nouvelle conversation avec un participant
-const createConversation = (participants) =>
-  api.post('/api/chat/conversations', { participants }).then(res => res.data);
+const createConversation = participants =>
+  api
+    .post('/api/chat/conversations', { participants })
+    .then(unwrap)
 
 
 // On exporte toutes les fonctions utiles

--- a/patrimoine-mtnd/src/tests/integration/chatService.test.js
+++ b/patrimoine-mtnd/src/tests/integration/chatService.test.js
@@ -1,30 +1,43 @@
+import api from '../../services/apiConfig'
 import chatService from '../../services/chatService'
 
-describe('Chat Service Integration Tests', () => {
+jest.mock('../../services/apiConfig', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    post: jest.fn()
+  }
+}))
+
+describe('Chat Service with updated API', () => {
   beforeEach(() => {
     jest.clearAllMocks()
   })
 
-  test('should create conversation successfully', async () => {
-    const mockResponse = { status: 'success', id: 1 }
-    chatService.createConversation = jest.fn().mockResolvedValue(mockResponse)
+  test('createConversation unwraps response and returns conversation', async () => {
+    api.post.mockResolvedValue({ data: { status: 'success', data: { id: 5, name: 'Test' } } })
 
-    const participants = [1, 2]
-    const result = await chatService.createConversation(participants)
+    const conv = await chatService.createConversation([1, 2])
 
-    expect(chatService.createConversation).toHaveBeenCalledWith(participants)
-    expect(result).toEqual(mockResponse)
+    expect(api.post).toHaveBeenCalledWith('/api/chat/conversations', { participants: [1, 2] })
+    expect(conv).toEqual({ id: 5, name: 'Test' })
   })
 
-  test('should send message successfully', async () => {
-    const mockResponse = { status: 'success', message_id: 10 }
-    chatService.sendMessage = jest.fn().mockResolvedValue(mockResponse)
+  test('fetchMessages attaches conversation id to each message', async () => {
+    api.get.mockResolvedValue({ data: { status: 'success', data: [{ id: 7, content: 'Hello' }] } })
 
-    const conversationId = 1
-    const content = 'Hello world'
-    const result = await chatService.sendMessage(conversationId, content)
+    const messages = await chatService.fetchMessages(10)
 
-    expect(chatService.sendMessage).toHaveBeenCalledWith(conversationId, content)
-    expect(result).toEqual(mockResponse)
+    expect(api.get).toHaveBeenCalledWith('/api/chat/conversations/10/messages')
+    expect(messages).toEqual([{ id: 7, content: 'Hello', conversation_id: 10 }])
+  })
+
+  test('sendMessage returns message with conversation id', async () => {
+    api.post.mockResolvedValue({ data: { status: 'success', data: { id: 8, content: 'Hi' } } })
+
+    const msg = await chatService.sendMessage(10, 'Hi')
+
+    expect(api.post).toHaveBeenCalledWith('/api/chat/conversations/10/messages', { content: 'Hi' })
+    expect(msg).toEqual({ id: 8, content: 'Hi', conversation_id: 10 })
   })
 })


### PR DESCRIPTION
## Summary
- update `chatService` to unwrap new `data` format and attach conversation IDs to messages
- rewrite integration tests for the chat service to mock the HTTP API and verify the new structure

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a73549ff48329bbe703daffa896e5