### PR TITLE
Fix message payloads in chat API

### DIFF
--- a/controllers/chat_controller.py
+++ b/controllers/chat_controller.py
@@ -28,9 +28,8 @@ class ChatController(http.Controller):
         return [
             {
                 'id': m.id,
-                'sender_id': m.sender_id.id,
-                'sender_name': m.sender_id.name,
-                'body': m.body,
+                'author_name': m.sender_id.name,
+                'content': m.body,
                 'date': m.date,
             }
             for m in messages
@@ -48,6 +47,8 @@ class ChatController(http.Controller):
         })
         return {
             'id': msg.id,
+            'author_name': msg.sender_id.name,
+            'content': msg.body,
             'date': msg.date,
         }
 


### PR DESCRIPTION
## Summary
- return `author_name` and `content` from chat API
- include full message details when posting a message

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint module resolution error)*

------
https://chatgpt.com/codex/tasks/task_e_686a736937688329a3dd7723c99ddf66