### PR TITLE
Handle unauthenticated chat requests

### DIFF
--- a/controllers/chat_controller.py
+++ b/controllers/chat_controller.py
@@ -5,6 +5,14 @@ import json
 class ChatController(http.Controller):
     @http.route('/api/chat/conversations', auth='user', type='http', methods=['GET'], csrf=False)
     def list_conversations(self, **kwargs):
+        public_uid = request.env.ref('base.public_user').id
+        if not request.session.uid or request.session.uid == public_uid:
+            return Response(
+                json.dumps({'error': 'Authentication required'}),
+                status=401,
+                headers={'Content-Type': 'application/json'}
+            )
+
         user = request.env.user
         conversations = request.env['chat.conversation'].sudo().search([
             ('participant_ids', 'in', user.id)

--- a/patrimoine-mtnd/src/tests/integration/chatService.test.js
+++ b/patrimoine-mtnd/src/tests/integration/chatService.test.js
@@ -40,4 +40,11 @@ describe('Chat Service with updated API', () => {
     expect(api.post).toHaveBeenCalledWith('/api/chat/conversations/10/messages', { content: 'Hi' })
     expect(msg).toEqual({ id: 8, content: 'Hi', conversation_id: 10 })
   })
+
+  test('fetchConversations propagates unauthorized errors', async () => {
+    const error = { response: { status: 401 } }
+    api.get.mockRejectedValue(error)
+
+    await expect(chatService.fetchConversations()).rejects.toBe(error)
+  })
 })


### PR DESCRIPTION
## Summary
- return HTTP 401 when listing conversations without a session
- test chat service error propagation on unauthorized

## Testing
- `npm test --prefix patrimoine-mtnd` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a794d92508329800b59a177c86a44