### PR TITLE
Configure longpolling proxy for dev server

### DIFF
--- a/patrimoine-mtnd/README.md
+++ b/patrimoine-mtnd/README.md
@@ -14,6 +14,8 @@ npm install
 npm run dev
 ```
 
+Le serveur de développement utilise un proxy afin de communiquer avec Odoo. Les routes `/api`, `/web`, `/websocket` ainsi que `/longpolling` sont redirigées vers les ports locaux d'Odoo. Pour `/longpolling`, la cible est `http://localhost:8072` et les options `changeOrigin` et `secure` correspondent aux autres règles.
+
 ## Construction pour la production
 
 ```bash

--- a/patrimoine-mtnd/vite.config.js
+++ b/patrimoine-mtnd/vite.config.js
@@ -37,6 +37,12 @@ export default defineConfig({
                 changeOrigin: true,
                 secure: false,
             },
+            // RÈGLE POUR /longpolling (bus Odoo)
+            "/longpolling": {
+                target: "http://localhost:8072",
+                changeOrigin: true,
+                secure: false,
+            },
         },
     },
     build: {


### PR DESCRIPTION
## Summary
- proxy longpolling requests to Odoo in `vite.config.js`
- mention the new proxy rule in the frontend README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aa4f7cbac832992899bf7d7e63b71