### PR TITLE
Implement chat bus notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ un espace de chat interne et un mur de posts pour partager les annonces du minis
 ## Dépendances
 - Odoo 17
 - Modules requis : base, hr, stock, account, fleet
+- Le serveur longpolling doit être actif pour permettre la messagerie temps réel
 
 ## Auteur
 **Ministère des Transports et du Numérique**  

--- a/tests/test_chat_notification.py
+++ b/tests/test_chat_notification.py
@@ -1,0 +1,30 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import models.chat as chat
+
+class ChatMessageNotificationTest(unittest.TestCase):
+    def test_create_triggers_bus_send(self):
+        fake_env = MagicMock()
+        fake_bus = MagicMock()
+        fake_env.__getitem__.return_value = fake_bus
+        fake_record = MagicMock()
+        fake_record.id = 1
+        fake_record.body = 'hi'
+        fake_record.conversation_id.participant_ids.mapped.return_value = [
+            MagicMock(partner_id=MagicMock(id=10)),
+            MagicMock(partner_id=MagicMock(id=11)),
+        ]
+        fake_record.sender_id.name = 'Demo'
+        fake_self = MagicMock()
+        fake_self.env = fake_env
+        fake_self._cr.dbname = 'test'
+        with patch('models.chat.models.Model.create', return_value=[fake_record]):
+            chat.ChatMessage.create(fake_self, [{'conversation_id': 1, 'body': 'hi'}])
+        fake_bus.sendmany.assert_called_once()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- send bus notifications on chat message creation
- mention the longpolling requirement in README
- add unit test checking that the bus is called

## Testing
- `npm test --silent` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'odoo')*

------
https://chatgpt.com/codex/tasks/task_e_686aa4f9ba70832985ecdee31b1a0d09