### PR TITLE
Update chat employee selection

### DIFF
--- a/controllers/asset_controller.py
+++ b/controllers/asset_controller.py
@@ -1068,7 +1068,14 @@ class PatrimoineAssetController(http.Controller):
         try:
             # Modèle hr.employee d'Odoo
             employees = request.env["hr.employee"].search([])
-            employee_data = [{"id": emp.id, "name": emp.name} for emp in employees]
+            employee_data = [
+                {
+                    "id": emp.id,
+                    "name": emp.name,
+                    "user_id": emp.user_id.id if emp.user_id else None,
+                }
+                for emp in employees
+            ]
             return Response(
                 json.dumps(employee_data), headers={"Content-Type": "application/json"}
             )

--- a/patrimoine-mtnd/src/components/chat/EmployeeList.jsx
+++ b/patrimoine-mtnd/src/components/chat/EmployeeList.jsx
@@ -16,8 +16,9 @@ export default function EmployeeList({ onSelect, onClose }) {
           {employees.map(emp => (
             <li
               key={emp.id}
-              onClick={() => onSelect(emp)}
-              className="p-2 cursor-pointer hover:bg-gray-800"
+              onClick={() => emp.user_id && onSelect(emp)}
+              className={`p-2 ${emp.user_id ? 'cursor-pointer hover:bg-gray-800' : 'text-gray-500 cursor-not-allowed'}`}
+              title={emp.user_id ? '' : "Aucun utilisateur associé"}
             >
               {emp.name}
             </li>

--- a/patrimoine-mtnd/src/pages/chat/ChatPage.jsx
+++ b/patrimoine-mtnd/src/pages/chat/ChatPage.jsx
@@ -4,6 +4,7 @@ import ConversationList from '../../components/chat/ConversationList'
 import ConversationView from '../../components/chat/ConversationView'
 import EmployeeList from '../../components/chat/EmployeeList'
 import useOdooBus from '../../hooks/useOdooBus'
+import { toast } from 'react-hot-toast'
 
 export default function ChatPage() {
   const [conversations, setConversations] = useState([])
@@ -38,7 +39,11 @@ export default function ChatPage() {
   useOdooBus(handleNewMessage)
 
   const startConversation = async emp => {
-    const conv = await chatService.createConversation([emp.id])
+    if (!emp.user_id) {
+      toast.error("Cet employé n'a pas de compte utilisateur")
+      return
+    }
+    const conv = await chatService.createConversation([emp.user_id])
     setConversations(prev => {
       if (prev.find(c => c.id === conv.id)) return prev
       return [...prev, conv]

--- a/patrimoine-mtnd/src/services/materialService.js
+++ b/patrimoine-mtnd/src/services/materialService.js
@@ -32,7 +32,12 @@ const fetchSubcategories = (categoryId = 0) => {
 const fetchLocations = () =>
     api.get("/api/patrimoine/locations").then(res => res.data)
 const fetchEmployees = () =>
-    api.get("/api/patrimoine/employees").then(res => res.data)
+    api
+        .get("/api/patrimoine/employees")
+        .then(res => res.data.map(emp => ({
+            ...emp,
+            user_id: emp.user_id ?? null,
+        })))
 const fetchDepartments = () =>
     api.get("/api/patrimoine/departments").then(res => res.data)
 const fetchFournisseurs = () =>


### PR DESCRIPTION
## Summary
- return user_id in employee API
- expose user_id in materialService
- prevent selecting employees without users
- create conversations with user_id

## Testing
- `pytest -q`
- `npm test --prefix patrimoine-mtnd`

------
https://chatgpt.com/codex/tasks/task_e_686aeb139ca483298eeead15ca3bc1ca