### PR TITLE
Remove redundant headers var

### DIFF
--- a/controllers/asset_controller.py
+++ b/controllers/asset_controller.py
@@ -2550,9 +2550,3 @@ class PatrimoineAssetController(http.Controller):
             return {"status": "error", "message": str(e)}
 
 
-headers = {
-    "Content-Type": "application/json",
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Methods": "POST, GET, OPTIONS",
-    "Access-Control-Allow-Headers": "Origin, Content-Type, X-Openerp-Session-Id",
-}


### PR DESCRIPTION
## Summary
- remove unused `headers` variable

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'odoo')*
- `python -m unittest` *(fails: ModuleNotFoundError: No module named 'odoo')*

------
https://chatgpt.com/codex/tasks/task_e_686afd59580c832991956faa6463c046