### PR TITLE
Add conversation header and auto-scroll

### DIFF
--- a/patrimoine-mtnd/src/components/chat/ConversationView.jsx
+++ b/patrimoine-mtnd/src/components/chat/ConversationView.jsx
@@ -1,7 +1,12 @@
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 
-export default function ConversationView({ messages, onSend }) {
+export default function ConversationView({ messages, onSend, conversationName }) {
   const [text, setText] = React.useState('')
+  const endRef = useRef(null)
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages])
 
   const handleSend = () => {
     if (text.trim()) {
@@ -12,6 +17,11 @@ export default function ConversationView({ messages, onSend }) {
 
   return (
     <div className="flex flex-col h-full">
+      {conversationName && (
+        <div className="px-4 py-2 border-b border-gray-700 text-sm font-semibold">
+          {conversationName}
+        </div>
+      )}
       <div className="flex-1 overflow-y-auto p-4 space-y-2">
         {messages.map(msg => (
           <div key={msg.id} className="flex flex-col">
@@ -21,6 +31,7 @@ export default function ConversationView({ messages, onSend }) {
             <span>{msg.content}</span>
           </div>
         ))}
+        <div ref={endRef} />
       </div>
       <div className="p-2 border-t border-gray-700 flex">
         <input

--- a/patrimoine-mtnd/src/pages/chat/ChatPage.jsx
+++ b/patrimoine-mtnd/src/pages/chat/ChatPage.jsx
@@ -68,7 +68,11 @@ export default function ChatPage() {
       </div>
       <div className="flex-1 flex flex-col">
         {current ? (
-          <ConversationView messages={messages} onSend={handleSend} />
+          <ConversationView
+            messages={messages}
+            onSend={handleSend}
+            conversationName={current.name}
+          />
         ) : (
           <div className="flex items-center justify-center h-full text-gray-400">
             Sélectionnez une conversation


### PR DESCRIPTION
## Summary
- display conversation name in chat viewer
- auto-scroll messages to bottom on update
- pass conversation name from chat page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686afd5eab648329a838168f7e2754d4