### PR TITLE
Add post attachments & API

### DIFF
--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -1,3 +1,4 @@
 from . import asset_controller
 from . import userApi_controller
 from . import chat_controller
+from . import post_controller

--- a/controllers/post_controller.py
+++ b/controllers/post_controller.py
@@ -1,0 +1,118 @@
+from odoo import http
+from odoo.http import request, Response
+import json
+import base64
+
+from .asset_controller import CORS_HEADERS, handle_api_errors
+
+
+class PostController(http.Controller):
+    @http.route('/api/intranet/posts', auth='user', type='http', methods=['GET'], csrf=False)
+    @handle_api_errors
+    def list_posts(self, **kwargs):
+        posts = request.env['intranet.post'].sudo().search([], order='create_date desc')
+        result = []
+        for post in posts:
+            result.append({
+                'id': post.id,
+                'title': post.name,
+                'body': post.body,
+                'author': post.user_id.name,
+                'create_date': post.create_date,
+                'type': post.post_type,
+                'attachments': [
+                    {'id': att.id, 'name': att.name}
+                    for att in post.attachment_ids
+                ],
+                'like_count': len(post.like_ids),
+                'comment_count': len(post.comment_ids),
+            })
+        return Response(
+            json.dumps({'status': 'success', 'data': result}, default=str),
+            headers=CORS_HEADERS,
+        )
+
+    @http.route('/api/intranet/posts', auth='user', type='http', methods=['POST'], csrf=False)
+    @handle_api_errors
+    def create_post(self, **post):
+        data = request.jsonrequest or {}
+        vals = {
+            'name': data.get('title', 'Post'),
+            'body': data.get('description'),
+            'post_type': data.get('type', 'text'),
+            'user_id': request.env.user.id,
+        }
+        record = request.env['intranet.post'].sudo().create(vals)
+
+        attachment_ids = []
+        for file_storage in request.httprequest.files.values():
+            attachment = request.env['ir.attachment'].sudo().create({
+                'name': file_storage.filename,
+                'datas': base64.b64encode(file_storage.read()),
+                'res_model': 'intranet.post',
+                'res_id': record.id,
+            })
+            attachment_ids.append(attachment.id)
+        if attachment_ids:
+            record.write({'attachment_ids': [(6, 0, attachment_ids)]})
+
+        return Response(
+            json.dumps({'status': 'success', 'data': {'id': record.id}}, default=str),
+            headers=CORS_HEADERS,
+        )
+
+    @http.route('/api/intranet/posts/<int:post_id>/comments', auth='user', type='http', methods=['POST'], csrf=False)
+    @handle_api_errors
+    def add_comment(self, post_id, **kw):
+        data = request.jsonrequest or {}
+        post = request.env['intranet.post'].sudo().browse(post_id)
+        if not post.exists():
+            return Response(
+                json.dumps({'status': 'error', 'code': 404, 'message': 'Post not found'}),
+                status=404,
+                headers=CORS_HEADERS,
+            )
+        comment = request.env['intranet.post.comment'].sudo().create({
+            'post_id': post.id,
+            'user_id': request.env.user.id,
+            'content': data.get('content'),
+        })
+        return Response(
+            json.dumps({
+                'status': 'success',
+                'data': {
+                    'id': comment.id,
+                    'content': comment.content,
+                    'author': comment.user_id.name,
+                    'date': comment.create_date,
+                },
+            }, default=str),
+            headers=CORS_HEADERS,
+        )
+
+    @http.route('/api/intranet/posts/<int:post_id>/likes', auth='user', type='http', methods=['POST'], csrf=False)
+    @handle_api_errors
+    def toggle_like(self, post_id, **kw):
+        post = request.env['intranet.post'].sudo().browse(post_id)
+        if not post.exists():
+            return Response(
+                json.dumps({'status': 'error', 'code': 404, 'message': 'Post not found'}),
+                status=404,
+                headers=CORS_HEADERS,
+            )
+
+        like_model = request.env['intranet.post.like'].sudo()
+        existing = like_model.search([
+            ('post_id', '=', post.id),
+            ('user_id', '=', request.env.user.id)
+        ], limit=1)
+        liked = False
+        if existing:
+            existing.unlink()
+        else:
+            like_model.create({'post_id': post.id, 'user_id': request.env.user.id})
+            liked = True
+        return Response(
+            json.dumps({'status': 'success', 'data': {'liked': liked}}, default=str),
+            headers=CORS_HEADERS,
+        )

--- a/models/post.py
+++ b/models/post.py
@@ -14,8 +14,74 @@ class IntranetPost(models.Model):
         required=True,
         default=lambda self: self.env.user,
     )
-    department_id = fields.Many2one(
-        "hr.department", string="D\xC3\xA9partement"
-    )
+    department_id = fields.Many2one("hr.department", string="D\xE9partement")
     image = fields.Image(string="Image")
+    attachment_ids = fields.Many2many(
+        "ir.attachment",
+        "intranet_post_attachment_rel",
+        "post_id",
+        "attachment_id",
+        string="Pi\xE8ces jointes",
+    )
+    post_type = fields.Selection(
+        [
+            ("text", "Texte"),
+            ("image", "Image"),
+            ("video", "Vid\xE9o"),
+            ("file", "Fichier"),
+        ],
+        string="Type",
+        default="text",
+    )
+    comment_ids = fields.One2many(
+        "intranet.post.comment", "post_id", string="Commentaires"
+    )
+    like_ids = fields.One2many(
+        "intranet.post.like", "post_id", string="Mentions j'aime"
+    )
+    share_ids = fields.One2many(
+        "intranet.post.share", "post_id", string="Partages"
+    )
     active = fields.Boolean(string="Actif", default=True)
+
+
+class IntranetPostComment(models.Model):
+    _name = "intranet.post.comment"
+    _description = "Commentaire de post"
+
+    post_id = fields.Many2one(
+        "intranet.post", string="Post", required=True, ondelete="cascade"
+    )
+    user_id = fields.Many2one(
+        "res.users", string="Auteur", required=True, default=lambda self: self.env.user
+    )
+    content = fields.Text(string="Commentaire", required=True)
+
+
+class IntranetPostLike(models.Model):
+    _name = "intranet.post.like"
+    _description = "Like de post"
+
+    post_id = fields.Many2one(
+        "intranet.post", string="Post", required=True, ondelete="cascade"
+    )
+    user_id = fields.Many2one(
+        "res.users", string="Utilisateur", required=True, default=lambda self: self.env.user
+    )
+
+    _sql_constraints = [
+        ("unique_like", "unique(post_id, user_id)", "Like d\xE9j\xE0 existant"),
+    ]
+
+
+class IntranetPostShare(models.Model):
+    _name = "intranet.post.share"
+    _description = "Partage de post"
+
+    post_id = fields.Many2one(
+        "intranet.post", string="Post", required=True, ondelete="cascade"
+    )
+    user_id = fields.Many2one(
+        "res.users", string="Utilisateur", required=True, default=lambda self: self.env.user
+    )
+    date_shared = fields.Datetime(string="Date", default=fields.Datetime.now)

--- a/security/ir.model.access.csv
+++ b/security/ir.model.access.csv
@@ -43,5 +43,14 @@ access_chat_message_admin,access.chat.message.admin,model_chat_message,gestion_p
 access_chat_message_director,access.chat.message.director,model_chat_message,gestion_patrimoine.group_patrimoine_director,1,1,1,1
 access_chat_message_agent,access.chat.message.agent,model_chat_message,gestion_patrimoine.group_patrimoine_agent,1,1,1,0
 access_intranet_post_admin,access.intranet.post.admin,model_intranet_post,gestion_patrimoine.group_patrimoine_admin,1,1,1,1
-access_intranet_post_director,access.intranet.post.director,model_intranet_post,gestion_patrimoine.group_patrimoine_director,1,1,1,1
+access_intranet_post_director,access.intranet.post.director,model_intranet_post,gestion_patrimoine.group_patrimoine_director,1,1,1,0
 access_intranet_post_agent,access.intranet.post.agent,model_intranet_post,gestion_patrimoine.group_patrimoine_agent,1,1,1,0
+access_post_comment_admin,access.post.comment.admin,model_intranet_post_comment,gestion_patrimoine.group_patrimoine_admin,1,1,1,1
+access_post_comment_director,access.post.comment.director,model_intranet_post_comment,gestion_patrimoine.group_patrimoine_director,1,1,1,0
+access_post_comment_agent,access.post.comment.agent,model_intranet_post_comment,gestion_patrimoine.group_patrimoine_agent,1,1,1,0
+access_post_like_admin,access.post.like.admin,model_intranet_post_like,gestion_patrimoine.group_patrimoine_admin,1,1,1,1
+access_post_like_director,access.post.like.director,model_intranet_post_like,gestion_patrimoine.group_patrimoine_director,1,1,1,0
+access_post_like_agent,access.post.like.agent,model_intranet_post_like,gestion_patrimoine.group_patrimoine_agent,1,1,1,0
+access_post_share_admin,access.post.share.admin,model_intranet_post_share,gestion_patrimoine.group_patrimoine_admin,1,1,1,1
+access_post_share_director,access.post.share.director,model_intranet_post_share,gestion_patrimoine.group_patrimoine_director,1,1,1,0
+access_post_share_agent,access.post.share.agent,model_intranet_post_share,gestion_patrimoine.group_patrimoine_agent,1,1,1,0

--- a/security/record_rules.xml
+++ b/security/record_rules.xml
@@ -19,6 +19,38 @@
                 eval="1"/>
             <field name="perm_unlink"
                 eval="1"/>
+    </record>
+
+        <!-- Posts, commentaires et likes -->
+        <record id="rule_post_general" model="ir.rule">
+            <field name="name">Posts - Acc\u00e8s g\u00e9n\u00e9ral</field>
+            <field name="model_id" ref="model_intranet_post"/>
+            <field name="groups" eval="[(4, ref('gestion_patrimoine.group_patrimoine_director')), (4, ref('gestion_patrimoine.group_patrimoine_agent'))]"/>
+            <field name="domain_force">[(1,'=',1)]</field>
+            <field name="perm_read" eval="1"/>
+            <field name="perm_write" eval="1"/>
+            <field name="perm_create" eval="1"/>
+            <field name="perm_unlink" eval="0"/>
+        </record>
+        <record id="rule_post_comment" model="ir.rule">
+            <field name="name">Commentaires - Acc\u00e8s</field>
+            <field name="model_id" ref="model_intranet_post_comment"/>
+            <field name="groups" eval="[(4, ref('gestion_patrimoine.group_patrimoine_director')), (4, ref('gestion_patrimoine.group_patrimoine_agent'))]"/>
+            <field name="domain_force">[(1,'=',1)]</field>
+            <field name="perm_read" eval="1"/>
+            <field name="perm_write" eval="1"/>
+            <field name="perm_create" eval="1"/>
+            <field name="perm_unlink" eval="0"/>
+        </record>
+        <record id="rule_post_like" model="ir.rule">
+            <field name="name">Likes - Acc\u00e8s</field>
+            <field name="model_id" ref="model_intranet_post_like"/>
+            <field name="groups" eval="[(4, ref('gestion_patrimoine.group_patrimoine_director')), (4, ref('gestion_patrimoine.group_patrimoine_agent'))]"/>
+            <field name="domain_force">[(1,'=',1)]</field>
+            <field name="perm_read" eval="1"/>
+            <field name="perm_write" eval="1"/>
+            <field name="perm_create" eval="1"/>
+            <field name="perm_unlink" eval="0"/>
         </record>
 
         <!-- Directeur : peut voir les catégories/sous-catégories de son département -->

--- a/tests/test_post_controller.py
+++ b/tests/test_post_controller.py
@@ -1,0 +1,46 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import controllers.post_controller as post_controller
+
+
+class PostControllerTest(unittest.TestCase):
+    def setUp(self):
+        self.controller = post_controller.PostController()
+
+    @patch('controllers.post_controller.request')
+    def test_list_posts_order(self, mock_request):
+        env = MagicMock()
+        posts = [
+            MagicMock(id=1, name='A', body='b', user_id=MagicMock(name='u'), create_date='2024-01-01', post_type='text', attachment_ids=[], like_ids=[], comment_ids=[]),
+            MagicMock(id=2, name='B', body='b', user_id=MagicMock(name='u'), create_date='2024-01-02', post_type='text', attachment_ids=[], like_ids=[], comment_ids=[]),
+        ]
+        env['intranet.post'].sudo().search.return_value = posts
+        mock_request.env = env
+        res = self.controller.list_posts()
+        env['intranet.post'].sudo().search.assert_called_with([], order='create_date desc')
+        self.assertIn('application/json', res.headers.get('Content-Type'))
+
+    @patch('controllers.post_controller.request')
+    def test_toggle_like_create(self, mock_request):
+        env = MagicMock()
+        post = MagicMock()
+        post.exists.return_value = True
+        env['intranet.post'].sudo().browse.return_value = post
+        like_model = MagicMock()
+        env['intranet.post.like'].sudo.return_value = like_model
+        like_model.search.return_value = []
+        mock_request.env = env
+        mock_request.env.user.id = 5
+
+        res = self.controller.toggle_like(1)
+        like_model.create.assert_called_once()
+        self.assertIn('application/json', res.headers.get('Content-Type'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/views/intranet_post_views.xml
+++ b/views/intranet_post_views.xml
@@ -23,6 +23,7 @@
                         <field name="name"/>
                         <field name="user_id" readonly="1"/>
                         <field name="department_id"/>
+                        <field name="post_type"/>
                         <field name="active"/>
                     </group>
                     <group>
@@ -30,15 +31,40 @@
                     </group>
                     <group>
                         <field name="image" widget="image" class="oe_avatar"/>
+                        <field name="attachment_ids" widget="many2many_binary"/>
                     </group>
                 </sheet>
             </form>
         </field>
     </record>
 
+    <record id="view_intranet_post_kanban" model="ir.ui.view">
+        <field name="name">intranet.post.kanban</field>
+        <field name="model">intranet.post</field>
+        <field name="arch" type="xml">
+            <kanban class="o_kanban_small_column">
+                <field name="image"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div class="oe_kanban_global_click">
+                            <t t-if="record.image.raw_value">
+                                <img t-att-src="'/web/image/intranet.post/' + record.id + '/image'" class="o_mini_avatar"/>
+                            </t>
+                            <div class="oe_kanban_details">
+                                <strong><field name="name"/></strong>
+                                <div><field name="body"/></div>
+                                <div class="oe_subtle"><field name="create_date"/></div>
+                            </div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
     <record id="action_intranet_post" model="ir.actions.act_window">
         <field name="name">Posts</field>
         <field name="res_model">intranet.post</field>
-        <field name="view_mode">tree,form</field>
+        <field name="view_mode">kanban,tree,form</field>
     </record>
 </odoo>


### PR DESCRIPTION
## Summary
- extend post model with attachments and new type field
- add comment, like and share models
- secure posts and interactions
- create controller for posts API
- display posts in new kanban backend view
- test post controller logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'odoo')*

------
https://chatgpt.com/codex/tasks/task_e_686b9e5c3adc8329b1dd9feb7c37dbde