### PR TITLE
Add posts feed components and tests

### DIFF
--- a/patrimoine-mtnd/src/components/posts/CreatePost.jsx
+++ b/patrimoine-mtnd/src/components/posts/CreatePost.jsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react'
+import postsService from '../../services/postsService'
+
+export default function CreatePost({ onCreated }) {
+  const [text, setText] = useState('')
+  const [file, setFile] = useState(null)
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = async e => {
+    e.preventDefault()
+    if (!text.trim() && !file) return
+
+    const formData = new FormData()
+    formData.append('body', text)
+    if (file) formData.append('file', file)
+
+    setLoading(true)
+    try {
+      const post = await postsService.createPost(formData)
+      onCreated && onCreated(post)
+      setText('')
+      setFile(null)
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="mb-4 bg-gray-900 p-4 rounded">
+      <textarea
+        className="w-full p-2 bg-gray-800 text-white rounded mb-2"
+        value={text}
+        onChange={e => setText(e.target.value)}
+        placeholder="Votre annonce..."
+      />
+      <input
+        type="file"
+        className="mb-2"
+        onChange={e => setFile(e.target.files[0])}
+      />
+      <button
+        type="submit"
+        className="bg-blue-500 text-white px-4 py-2 rounded"
+        disabled={loading}
+      >
+        Publier
+      </button>
+    </form>
+  )
+}

--- a/patrimoine-mtnd/src/components/posts/Post.jsx
+++ b/patrimoine-mtnd/src/components/posts/Post.jsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react'
+import postsService from '../../services/postsService'
+
+export default function Post({ post }) {
+  const [likes, setLikes] = useState(post.likes || 0)
+  const [comments, setComments] = useState(post.comments || [])
+  const [text, setText] = useState('')
+
+  const handleLike = async () => {
+    try {
+      await postsService.likePost(post.id)
+      setLikes(likes + 1)
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  const handleShare = async () => {
+    try {
+      await postsService.sharePost(post.id)
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  const handleComment = async () => {
+    if (!text.trim()) return
+    try {
+      const c = await postsService.addComment(post.id, text)
+      setComments([...comments, c])
+      setText('')
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  return (
+    <div className="bg-gray-900 p-4 rounded mb-4">
+      <h3 className="font-semibold mb-2">{post.name}</h3>
+      <p className="mb-2 whitespace-pre-wrap">{post.body}</p>
+      {post.image && (
+        <img
+          src={post.image}
+          alt=""
+          className="mb-2 max-h-60 object-cover w-full rounded"
+        />
+      )}
+      <div className="flex space-x-4 mb-2 text-sm">
+        <button onClick={handleLike} className="text-blue-400">
+          J'aime ({likes})
+        </button>
+        <button onClick={handleShare} className="text-blue-400">Partager</button>
+      </div>
+      <div className="space-y-2">
+        {comments.map((c, idx) => (
+          <p key={idx} className="text-sm">
+            {c.author_name ? (
+              <span className="font-semibold">{c.author_name}: </span>
+            ) : null}
+            {c.body || c.comment}
+          </p>
+        ))}
+      </div>
+      <div className="mt-2 flex">
+        <input
+          className="flex-1 bg-gray-800 p-2 rounded mr-2"
+          value={text}
+          onChange={e => setText(e.target.value)}
+          placeholder="Commenter..."
+        />
+        <button
+          onClick={handleComment}
+          className="bg-blue-500 text-white px-3 rounded"
+        >
+          Envoyer
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/patrimoine-mtnd/src/components/posts/PostsList.jsx
+++ b/patrimoine-mtnd/src/components/posts/PostsList.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import Post from './Post'
+
+export default function PostsList({ posts }) {
+  return (
+    <div>
+      {posts.map(p => (
+        <Post key={p.id} post={p} />
+      ))}
+    </div>
+  )
+}

--- a/patrimoine-mtnd/src/pages/posts/PostsPage.jsx
+++ b/patrimoine-mtnd/src/pages/posts/PostsPage.jsx
@@ -1,10 +1,22 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react'
+import postsService from '../../services/postsService'
+import CreatePost from '../../components/posts/CreatePost'
+import PostsList from '../../components/posts/PostsList'
 
 export default function PostsPage() {
-    return (
-        <div className="p-6">
-            <h1 className="text-2xl font-bold mb-4">Mur de posts</h1>
-            <p>Ici les membres du ministère pourront partager des annonces.</p>
-        </div>
-    );
+  const [posts, setPosts] = useState([])
+
+  useEffect(() => {
+    postsService.fetchPosts().then(setPosts).catch(() => {})
+  }, [])
+
+  const addPost = post => setPosts(prev => [post, ...prev])
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Mur de posts</h1>
+      <CreatePost onCreated={addPost} />
+      <PostsList posts={posts} />
+    </div>
+  )
 }

--- a/patrimoine-mtnd/src/services/postsService.js
+++ b/patrimoine-mtnd/src/services/postsService.js
@@ -1,0 +1,30 @@
+import api from './apiConfig'
+
+const fetchPosts = () =>
+  api.get('/api/intranet/posts').then(res => res.data)
+
+const createPost = formData =>
+  api
+    .post('/api/intranet/posts', formData, {
+      headers: { 'Content-Type': 'multipart/form-data' }
+    })
+    .then(res => res.data)
+
+const likePost = id =>
+  api.post(`/api/intranet/posts/${id}/like`).then(res => res.data)
+
+const sharePost = id =>
+  api.post(`/api/intranet/posts/${id}/share`).then(res => res.data)
+
+const addComment = (id, comment) =>
+  api
+    .post(`/api/intranet/posts/${id}/comments`, { comment })
+    .then(res => res.data)
+
+export default {
+  fetchPosts,
+  createPost,
+  likePost,
+  sharePost,
+  addComment
+}

--- a/patrimoine-mtnd/src/tests/integration/postsPage.test.jsx
+++ b/patrimoine-mtnd/src/tests/integration/postsPage.test.jsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import { act } from 'react-dom/test-utils'
+import ReactDOM from 'react-dom/client'
+import postsService from '../../services/postsService'
+import PostsPage from '../../pages/posts/PostsPage'
+
+jest.mock('../../services/postsService', () => ({
+  __esModule: true,
+  default: {
+    fetchPosts: jest.fn(),
+    createPost: jest.fn(),
+    likePost: jest.fn(),
+    sharePost: jest.fn(),
+    addComment: jest.fn()
+  }
+}))
+
+describe('PostsPage behaviour', () => {
+  let container
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    document.body.removeChild(container)
+    container = null
+  })
+
+  test('loads posts on mount', async () => {
+    postsService.fetchPosts.mockResolvedValue([{ id: 1, name: 't', body: 'b' }])
+
+    await act(async () => {
+      ReactDOM.createRoot(container).render(<PostsPage />)
+    })
+    await act(() => Promise.resolve())
+
+    expect(container.textContent).toContain('t')
+  })
+
+  test('new post appears first', async () => {
+    postsService.fetchPosts.mockResolvedValue([{ id: 1, name: 'old', body: 'old' }])
+    postsService.createPost.mockResolvedValue({ id: 2, name: 'new', body: 'new' })
+
+    await act(async () => {
+      ReactDOM.createRoot(container).render(<PostsPage />)
+    })
+    await act(() => Promise.resolve())
+
+    const textarea = container.querySelector('textarea')
+    const button = container.querySelector('button')
+
+    await act(async () => {
+      textarea.value = 'new'
+      textarea.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await act(() => Promise.resolve())
+
+    const firstTitle = container.querySelector('h3').textContent
+    expect(firstTitle).toBe('new')
+  })
+})

--- a/patrimoine-mtnd/src/tests/integration/postsService.test.js
+++ b/patrimoine-mtnd/src/tests/integration/postsService.test.js
@@ -1,0 +1,48 @@
+import api from '../../services/apiConfig'
+import postsService from '../../services/postsService'
+
+jest.mock('../../services/apiConfig', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    post: jest.fn()
+  }
+}))
+
+describe('postsService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('fetchPosts returns list of posts', async () => {
+    api.get.mockResolvedValue({ data: [{ id: 1 }] })
+
+    const posts = await postsService.fetchPosts()
+
+    expect(api.get).toHaveBeenCalledWith('/api/intranet/posts')
+    expect(posts).toEqual([{ id: 1 }])
+  })
+
+  test('createPost sends form data', async () => {
+    const fd = new FormData()
+    api.post.mockResolvedValue({ data: { id: 2 } })
+
+    const post = await postsService.createPost(fd)
+
+    expect(api.post).toHaveBeenCalledWith(
+      '/api/intranet/posts',
+      fd,
+      { headers: { 'Content-Type': 'multipart/form-data' } }
+    )
+    expect(post).toEqual({ id: 2 })
+  })
+
+  test('likePost calls like endpoint', async () => {
+    api.post.mockResolvedValue({ data: { likes: 5 } })
+
+    const res = await postsService.likePost(3)
+
+    expect(api.post).toHaveBeenCalledWith('/api/intranet/posts/3/like')
+    expect(res).toEqual({ likes: 5 })
+  })
+})


### PR DESCRIPTION
## Summary
- implement postsService for intranet post APIs
- add CreatePost, Post and PostsList components
- replace PostsPage placeholder with new feed
- add integration tests for posts service and page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b9e60d6cc832998bafee0a30d9ff5