### PR TITLE
Fix intranet posts endpoints

### DIFF
--- a/patrimoine-mtnd/src/components/posts/Post.jsx
+++ b/patrimoine-mtnd/src/components/posts/Post.jsx
@@ -15,13 +15,6 @@ export default function Post({ post }) {
     }
   }
 
-  const handleShare = async () => {
-    try {
-      await postsService.sharePost(post.id)
-    } catch (e) {
-      console.error(e)
-    }
-  }
 
   const handleComment = async () => {
     if (!text.trim()) return
@@ -49,7 +42,6 @@ export default function Post({ post }) {
         <button onClick={handleLike} className="text-blue-400">
           J'aime ({likes})
         </button>
-        <button onClick={handleShare} className="text-blue-400">Partager</button>
       </div>
       <div className="space-y-2">
         {comments.map((c, idx) => (

--- a/patrimoine-mtnd/src/services/postsService.js
+++ b/patrimoine-mtnd/src/services/postsService.js
@@ -11,20 +11,16 @@ const createPost = formData =>
     .then(res => res.data)
 
 const likePost = id =>
-  api.post(`/api/intranet/posts/${id}/like`).then(res => res.data)
+  api.post(`/api/intranet/posts/${id}/likes`).then(res => res.data)
 
-const sharePost = id =>
-  api.post(`/api/intranet/posts/${id}/share`).then(res => res.data)
-
-const addComment = (id, comment) =>
+const addComment = (id, content) =>
   api
-    .post(`/api/intranet/posts/${id}/comments`, { comment })
+    .post(`/api/intranet/posts/${id}/comments`, { content })
     .then(res => res.data)
 
 export default {
   fetchPosts,
   createPost,
   likePost,
-  sharePost,
   addComment
 }

--- a/patrimoine-mtnd/src/tests/integration/postsPage.test.jsx
+++ b/patrimoine-mtnd/src/tests/integration/postsPage.test.jsx
@@ -10,7 +10,6 @@ jest.mock('../../services/postsService', () => ({
     fetchPosts: jest.fn(),
     createPost: jest.fn(),
     likePost: jest.fn(),
-    sharePost: jest.fn(),
     addComment: jest.fn()
   }
 }))

--- a/patrimoine-mtnd/src/tests/integration/postsService.test.js
+++ b/patrimoine-mtnd/src/tests/integration/postsService.test.js
@@ -42,7 +42,7 @@ describe('postsService', () => {
 
     const res = await postsService.likePost(3)
 
-    expect(api.post).toHaveBeenCalledWith('/api/intranet/posts/3/like')
+    expect(api.post).toHaveBeenCalledWith('/api/intranet/posts/3/likes')
     expect(res).toEqual({ likes: 5 })
   })
 })


### PR DESCRIPTION
## Summary
- target the correct like URL for posts
- drop sharePost helper and button since there is no backend route
- fix addComment payload
- update unit tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ba94684688329b98436038c4b892c