### PR TITLE
Update Post component fields

### DIFF
--- a/patrimoine-mtnd/src/components/posts/Post.jsx
+++ b/patrimoine-mtnd/src/components/posts/Post.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import postsService from '../../services/postsService'
 
 export default function Post({ post }) {
-  const [likes, setLikes] = useState(post.likes || 0)
+  const [likes, setLikes] = useState(post.like_count || 0)
   const [comments, setComments] = useState(post.comments || [])
   const [text, setText] = useState('')
 
@@ -27,7 +27,7 @@ export default function Post({ post }) {
     if (!text.trim()) return
     try {
       const c = await postsService.addComment(post.id, text)
-      setComments([...comments, c])
+      setComments([...comments, { ...c, comment: text }])
       setText('')
     } catch (e) {
       console.error(e)
@@ -36,7 +36,7 @@ export default function Post({ post }) {
 
   return (
     <div className="bg-gray-900 p-4 rounded mb-4">
-      <h3 className="font-semibold mb-2">{post.name}</h3>
+      <h3 className="font-semibold mb-2">{post.title}</h3>
       <p className="mb-2 whitespace-pre-wrap">{post.body}</p>
       {post.image && (
         <img

--- a/patrimoine-mtnd/src/tests/integration/postsPage.test.jsx
+++ b/patrimoine-mtnd/src/tests/integration/postsPage.test.jsx
@@ -30,7 +30,7 @@ describe('PostsPage behaviour', () => {
   })
 
   test('loads posts on mount', async () => {
-    postsService.fetchPosts.mockResolvedValue([{ id: 1, name: 't', body: 'b' }])
+    postsService.fetchPosts.mockResolvedValue([{ id: 1, title: 't', body: 'b' }])
 
     await act(async () => {
       ReactDOM.createRoot(container).render(<PostsPage />)
@@ -41,8 +41,8 @@ describe('PostsPage behaviour', () => {
   })
 
   test('new post appears first', async () => {
-    postsService.fetchPosts.mockResolvedValue([{ id: 1, name: 'old', body: 'old' }])
-    postsService.createPost.mockResolvedValue({ id: 2, name: 'new', body: 'new' })
+    postsService.fetchPosts.mockResolvedValue([{ id: 1, title: 'old', body: 'old' }])
+    postsService.createPost.mockResolvedValue({ id: 2, title: 'new', body: 'new' })
 
     await act(async () => {
       ReactDOM.createRoot(container).render(<PostsPage />)


### PR DESCRIPTION
## Summary
- adapt Post component to use `title` and `like_count`
- build local comment object when `addComment` only returns an id
- update integration tests to use new post fields

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ba94a08b08329be9a5996a161c26b