### PR TITLE
Update integration tests

### DIFF
--- a/patrimoine-mtnd/src/tests/integration/hrService.test.js
+++ b/patrimoine-mtnd/src/tests/integration/hrService.test.js
@@ -14,7 +14,7 @@ describe('HR Service fetches', () => {
 
     const result = await fetchEmployees()
 
-    expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('/api/hr/employees'))
+    expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('/api/patrimoine/employees'))
     expect(result).toEqual(mockData)
   })
 
@@ -24,7 +24,7 @@ describe('HR Service fetches', () => {
 
     const result = await fetchDepartments()
 
-    expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('/api/hr/departments'))
+    expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('/api/patrimoine/departments'))
     expect(result).toEqual(mockData)
   })
 })

--- a/patrimoine-mtnd/src/tests/integration/postsService.test.js
+++ b/patrimoine-mtnd/src/tests/integration/postsService.test.js
@@ -15,17 +15,17 @@ describe('postsService', () => {
   })
 
   test('fetchPosts returns list of posts', async () => {
-    api.get.mockResolvedValue({ data: [{ id: 1 }] })
+    api.get.mockResolvedValue({ data: { status: 'success', data: [{ id: 1 }] } })
 
     const posts = await postsService.fetchPosts()
 
     expect(api.get).toHaveBeenCalledWith('/api/intranet/posts')
-    expect(posts).toEqual([{ id: 1 }])
+    expect(posts).toEqual({ status: 'success', data: [{ id: 1 }] })
   })
 
   test('createPost sends form data', async () => {
     const fd = new FormData()
-    api.post.mockResolvedValue({ data: { id: 2 } })
+    api.post.mockResolvedValue({ data: { status: 'success', data: { id: 2 } } })
 
     const post = await postsService.createPost(fd)
 
@@ -34,15 +34,15 @@ describe('postsService', () => {
       fd,
       { headers: { 'Content-Type': 'multipart/form-data' } }
     )
-    expect(post).toEqual({ id: 2 })
+    expect(post).toEqual({ status: 'success', data: { id: 2 } })
   })
 
   test('likePost calls like endpoint', async () => {
-    api.post.mockResolvedValue({ data: { likes: 5 } })
+    api.post.mockResolvedValue({ data: { status: 'success', data: { liked: true, like_count: 5 } } })
 
     const res = await postsService.likePost(3)
 
-    expect(api.post).toHaveBeenCalledWith('/api/intranet/posts/3/like')
-    expect(res).toEqual({ likes: 5 })
+    expect(api.post).toHaveBeenCalledWith('/api/intranet/posts/3/likes')
+    expect(res).toEqual({ status: 'success', data: { liked: true, like_count: 5 } })
   })
 })


### PR DESCRIPTION
## Summary
- update postsService integration test for new success response shape
- adjust HR service tests to match patrimoine endpoints

## Testing
- `npm test` *(fails: jest not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'odoo')*

------
https://chatgpt.com/codex/tasks/task_e_686ba94ad0308329b087987e4ad03c51