### PR TITLE
Fix toggle_like response formatting

### DIFF
--- a/controllers/post_controller.py
+++ b/controllers/post_controller.py
@@ -111,4 +111,13 @@ class IntranetPostController(http.Controller):
             like_model.create({'post_id': post.id, 'user_id': request.env.user.id})
             liked = True
             
-        return Response(json.dumps({'status': 'success', 'data': {'liked': liked, 'like_count': len(post.like_ids)}}), default=str), headers=CORS_HEADERS)
+        return Response(
+            json.dumps(
+                {
+                    'status': 'success',
+                    'data': {'liked': liked, 'like_count': len(post.like_ids)},
+                },
+                default=str,
+            ),
+            headers=CORS_HEADERS,
+        )

--- a/tests/test_post_controller.py
+++ b/tests/test_post_controller.py
@@ -10,7 +10,7 @@ import controllers.post_controller as post_controller
 
 class PostControllerTest(unittest.TestCase):
     def setUp(self):
-        self.controller = post_controller.PostController()
+        self.controller = post_controller.IntranetPostController()
 
     @patch('controllers.post_controller.request')
     def test_list_posts_order(self, mock_request):


### PR DESCRIPTION
## Summary
- fix the response construction in `toggle_like`
- update controller test setup to use `IntranetPostController`

## Testing
- `python3 -m pytest -q` *(fails: ModuleNotFoundError: No module named 'odoo')*

------
https://chatgpt.com/codex/tasks/task_e_686bc8edc22c8329ba82ef6a4d98cf1b