### PR TITLE
Fix post creation request

### DIFF
--- a/patrimoine-mtnd/src/services/postsService.js
+++ b/patrimoine-mtnd/src/services/postsService.js
@@ -5,9 +5,7 @@ const fetchPosts = () =>
 
 const createPost = formData =>
   api
-    .post('/api/intranet/posts', formData, {
-      headers: { 'Content-Type': 'multipart/form-data' }
-    })
+    .post('/api/intranet/posts', formData)
     .then(res => res.data)
 
 const likePost = id =>

--- a/patrimoine-mtnd/src/tests/integration/postsService.test.js
+++ b/patrimoine-mtnd/src/tests/integration/postsService.test.js
@@ -29,11 +29,7 @@ describe('postsService', () => {
 
     const post = await postsService.createPost(fd)
 
-    expect(api.post).toHaveBeenCalledWith(
-      '/api/intranet/posts',
-      fd,
-      { headers: { 'Content-Type': 'multipart/form-data' } }
-    )
+    expect(api.post).toHaveBeenCalledWith('/api/intranet/posts', fd)
     expect(post).toEqual({ status: 'success', data: { id: 2 } })
   })
 


### PR DESCRIPTION
## Summary
- remove manual `Content-Type` header from `postsService`
- update integration test to match new request signature

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bd3032f6083298f9a8dc80704b862