### PR TITLE
Fix tests to use IntranetPostController

### DIFF
--- a/tests/test_post_controller.py
+++ b/tests/test_post_controller.py
@@ -10,7 +10,7 @@ import controllers.post_controller as post_controller
 
 class PostControllerTest(unittest.TestCase):
     def setUp(self):
-        self.controller = post_controller.PostController()
+        self.controller = post_controller.IntranetPostController()
 
     @patch('controllers.post_controller.request')
     def test_list_posts_order(self, mock_request):


### PR DESCRIPTION
## Summary
- update the post controller tests to instantiate `IntranetPostController`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'odoo')*

------
https://chatgpt.com/codex/tasks/task_e_686be82eb90083299e16f6d0a655440a