### PR TITLE
Add author_id alias for posts

### DIFF
--- a/controllers/post_controller.py
+++ b/controllers/post_controller.py
@@ -22,7 +22,7 @@ class IntranetPostController(http.Controller):
                 'id': post.id,
                 'title': post.name,
                 'body': post.body,
-                'author': post.user_id.name,
+                'author': post.author_id.name,
                 'create_date': post.create_date,
                 'type': post.post_type,
                 'image': f"/web/image/intranet.post/{post.id}/image" if post.image else None,
@@ -47,7 +47,7 @@ class IntranetPostController(http.Controller):
             'name': post.get('name'),
             'body': post.get('body'),
             'post_type': post.get('type', 'text'),
-            'user_id': request.env.user.id,
+            'author_id': request.env.user.id,
             'department_id': int(post.get('department_id')) if post.get('department_id') else False,
         }
         

--- a/models/post.py
+++ b/models/post.py
@@ -13,6 +13,15 @@ class IntranetPost(models.Model):
         required=True,
         default=lambda self: self.env.user,
     )
+    author_id = fields.Many2one(
+        "res.users",
+        string="Auteur",
+        required=True,
+        default=lambda self: self.env.user,
+        related="user_id",
+        store=True,
+        readonly=False,
+    )
     department_id = fields.Many2one("hr.department", string="Département")
     image = fields.Image(string="Image")
     attachment_ids = fields.Many2many(

--- a/tests/test_post_controller.py
+++ b/tests/test_post_controller.py
@@ -16,8 +16,8 @@ class PostControllerTest(unittest.TestCase):
     def test_list_posts_order(self, mock_request):
         env = MagicMock()
         posts = [
-            MagicMock(id=1, name='A', body='b', user_id=MagicMock(name='u'), create_date='2024-01-01', post_type='text', attachment_ids=[], like_ids=[], comment_ids=[]),
-            MagicMock(id=2, name='B', body='b', user_id=MagicMock(name='u'), create_date='2024-01-02', post_type='text', attachment_ids=[], like_ids=[], comment_ids=[]),
+            MagicMock(id=1, name='A', body='b', author_id=MagicMock(name='u'), create_date='2024-01-01', post_type='text', attachment_ids=[], like_ids=[], comment_ids=[]),
+            MagicMock(id=2, name='B', body='b', author_id=MagicMock(name='u'), create_date='2024-01-02', post_type='text', attachment_ids=[], like_ids=[], comment_ids=[]),
         ]
         env['intranet.post'].sudo().search.return_value = posts
         mock_request.env = env

--- a/views/intranet_post_views.xml
+++ b/views/intranet_post_views.xml
@@ -6,7 +6,7 @@
         <field name="arch" type="xml">
             <tree string="Publications">
                 <field name="name"/>
-                <field name="user_id"/>
+                <field name="author_id"/>
                 <field name="department_id" optional="show"/>
                 <field name="create_date"/>
             </tree>
@@ -21,7 +21,7 @@
                 <sheet>
                     <group>
                         <field name="name"/>
-                        <field name="user_id" readonly="1"/>
+                        <field name="author_id" readonly="1"/>
                         <field name="department_id"/>
                         <field name="post_type"/>
                         <field name="active"/>


### PR DESCRIPTION
## Summary
- add `author_id` related field for posts
- display `author_id` in intranet post views
- use `author_id` in the post controller
- adjust tests for new field

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'odoo')*

------
https://chatgpt.com/codex/tasks/task_e_686bff5464d48329b4fbb015e12225d9