### PR TITLE
Add validation for intranet post creation

### DIFF
--- a/controllers/post_controller.py
+++ b/controllers/post_controller.py
@@ -3,6 +3,7 @@ import base64
 import logging
 from odoo import http
 from odoo.http import request, Response
+from odoo.exceptions import ValidationError
 
 # Assurez-vous que handle_api_errors est bien importé depuis votre autre contrôleur
 from .asset_controller import handle_api_errors, CORS_HEADERS
@@ -43,8 +44,12 @@ class IntranetPostController(http.Controller):
     @handle_api_errors
     def create_post(self, **post):
         # On utilise `post` directement au lieu de `request.jsonrequest` car c'est un formulaire multipart/form-data
+        name = post.get('name')
+        if not name:
+            raise ValidationError("Le champ 'name' est obligatoire.")
+
         vals = {
-            'name': post.get('name'),
+            'name': name,
             'body': post.get('body'),
             'post_type': post.get('type', 'text'),
             'author_id': request.env.user.id,

--- a/tests/test_post_controller.py
+++ b/tests/test_post_controller.py
@@ -41,6 +41,17 @@ class PostControllerTest(unittest.TestCase):
         like_model.create.assert_called_once()
         self.assertIn('application/json', res.headers.get('Content-Type'))
 
+    @patch('controllers.post_controller.request')
+    def test_create_post_missing_name_returns_400(self, mock_request):
+        env = MagicMock()
+        mock_request.env = env
+        mock_request.httprequest.files = {}
+
+        res = self.controller.create_post()
+
+        self.assertEqual(res.status_code, 400)
+        env['intranet.post'].sudo().create.assert_not_called()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add ValidationError handling for intranet post creation
- ensure missing post name returns 400
- test missing-name case

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'odoo')*

------
https://chatgpt.com/codex/tasks/task_e_686c02f4237c8329a58459d2ec81cfc3