### PR TITLE
Improve create_post JSON handling

### DIFF
--- a/controllers/post_controller.py
+++ b/controllers/post_controller.py
@@ -43,17 +43,17 @@ class IntranetPostController(http.Controller):
     @http.route('/api/intranet/posts', auth='user', type='http', methods=['POST'], csrf=False)
     @handle_api_errors
     def create_post(self, **post):
-        # On utilise `post` directement au lieu de `request.jsonrequest` car c'est un formulaire multipart/form-data
-        name = post.get('name')
+        data = post or request.jsonrequest or {}
+        name = data.get('name')
         if not name:
             raise ValidationError("Le champ 'name' est obligatoire.")
 
         vals = {
             'name': name,
-            'body': post.get('body'),
-            'post_type': post.get('type', 'text'),
+            'body': data.get('body'),
+            'post_type': data.get('type', 'text'),
             'author_id': request.env.user.id,
-            'department_id': int(post.get('department_id')) if post.get('department_id') else False,
+            'department_id': int(data.get('department_id')) if data.get('department_id') else False,
         }
         
         # Gestion de l'image

--- a/tests/test_post_controller.py
+++ b/tests/test_post_controller.py
@@ -46,6 +46,19 @@ class PostControllerTest(unittest.TestCase):
         env = MagicMock()
         mock_request.env = env
         mock_request.httprequest.files = {}
+        mock_request.jsonrequest = None
+
+        res = self.controller.create_post()
+
+        self.assertEqual(res.status_code, 400)
+        env['intranet.post'].sudo().create.assert_not_called()
+
+    @patch('controllers.post_controller.request')
+    def test_create_post_json_missing_name_returns_400(self, mock_request):
+        env = MagicMock()
+        mock_request.env = env
+        mock_request.httprequest.files = {}
+        mock_request.jsonrequest = {}
 
         res = self.controller.create_post()
 


### PR DESCRIPTION
## Summary
- read request data from JSON payload when form data empty
- validate post name with either form or JSON payload
- update vals to use unified data object
- test JSON create_post validation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'odoo')*

------
https://chatgpt.com/codex/tasks/task_e_686c0fd8d5e083298ae609e58e0212af