### PR TITLE
Add title validation in CreatePost

### DIFF
--- a/patrimoine-mtnd/src/components/posts/CreatePost.jsx
+++ b/patrimoine-mtnd/src/components/posts/CreatePost.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import postsService from '../../services/postsService'
 
 export default function CreatePost({ onCreated }) {
-  const [title, setTitle] = useState('')
+  const [name, setName] = useState('')
   const [text, setText] = useState('')
   const [file, setFile] = useState(null)
   const [loading, setLoading] = useState(false)
@@ -11,16 +11,21 @@ export default function CreatePost({ onCreated }) {
     e.preventDefault()
     if (!text.trim() && !file) return
 
+    if (!name.trim()) {
+      alert('Le titre est obligatoire')
+      return
+    }
+
     const formData = new FormData()
     formData.append('body', text)
-    formData.append('name', title)
+    formData.append('name', name)
     if (file) formData.append('image', file)
 
     setLoading(true)
     try {
       const post = await postsService.createPost(formData)
       onCreated && onCreated(post)
-      setTitle('')
+      setName('')
       setText('')
       setFile(null)
     } catch (err) {
@@ -34,8 +39,8 @@ export default function CreatePost({ onCreated }) {
     <form onSubmit={handleSubmit} className="mb-4 bg-gray-900 p-4 rounded">
       <input
         className="w-full p-2 bg-gray-800 text-white rounded mb-2"
-        value={title}
-        onChange={e => setTitle(e.target.value)}
+        value={name}
+        onChange={e => setName(e.target.value)}
         placeholder="Titre"
       />
       <textarea

--- a/patrimoine-mtnd/src/tests/integration/postsPage.test.jsx
+++ b/patrimoine-mtnd/src/tests/integration/postsPage.test.jsx
@@ -48,10 +48,13 @@ describe('PostsPage behaviour', () => {
     })
     await act(() => Promise.resolve())
 
+    const titleInput = container.querySelector('input[placeholder="Titre"]')
     const textarea = container.querySelector('textarea')
     const button = container.querySelector('button')
 
     await act(async () => {
+      titleInput.value = 'titre'
+      titleInput.dispatchEvent(new Event('input', { bubbles: true }))
       textarea.value = 'new'
       textarea.dispatchEvent(new Event('input', { bubbles: true }))
     })


### PR DESCRIPTION
## Summary
- ensure a title is provided before creating a post
- rename `title` state to `name`
- adapt `PostsPage` integration test to fill the title field

## Testing
- `npm --prefix patrimoine-mtnd test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cc88a60b08329a1ec98368992a701