### PR TITLE
Improve post creation flow

### DIFF
--- a/controllers/post_controller.py
+++ b/controllers/post_controller.py
@@ -76,8 +76,28 @@ class IntranetPostController(http.Controller):
         if attachment_ids:
             record.write({'attachment_ids': [(6, 0, attachment_ids)]})
 
+        post_data = {
+            'id': record.id,
+            'title': record.name,
+            'body': record.body,
+            'author': record.author_id.name,
+            'create_date': record.create_date,
+            'type': record.post_type,
+            'image': f"/web/image/intranet.post/{record.id}/image" if record.image else None,
+            'attachments': [
+                {
+                    'id': att.id,
+                    'name': att.name,
+                    'url': f"/web/content/{att.id}?download=1",
+                }
+                for att in record.attachment_ids
+            ],
+            'like_count': len(record.like_ids),
+            'comment_count': len(record.comment_ids),
+        }
+
         return Response(
-            json.dumps({'status': 'success', 'data': {'id': record.id}}, default=str),
+            json.dumps({'status': 'success', 'data': post_data}, default=str),
             headers=CORS_HEADERS,
         )
 

--- a/patrimoine-mtnd/src/components/posts/CreatePost.jsx
+++ b/patrimoine-mtnd/src/components/posts/CreatePost.jsx
@@ -18,8 +18,9 @@ export default function CreatePost({ onCreated }) {
 
     setLoading(true)
     try {
-      const post = await postsService.createPost(formData)
-      onCreated && onCreated(post)
+      const response = await postsService.createPost(formData)
+      const newPost = response.data
+      onCreated && onCreated(newPost)
       setTitle('')
       setText('')
       setFile(null)

--- a/patrimoine-mtnd/src/tests/integration/postsPage.test.jsx
+++ b/patrimoine-mtnd/src/tests/integration/postsPage.test.jsx
@@ -41,7 +41,10 @@ describe('PostsPage behaviour', () => {
 
   test('new post appears first', async () => {
     postsService.fetchPosts.mockResolvedValue([{ id: 1, title: 'old', body: 'old' }])
-    postsService.createPost.mockResolvedValue({ id: 2, title: 'new', body: 'new' })
+    postsService.createPost.mockResolvedValue({
+      status: 'success',
+      data: { id: 2, title: 'new', body: 'new' }
+    })
 
     await act(async () => {
       ReactDOM.createRoot(container).render(<PostsPage />)


### PR DESCRIPTION
## Summary
- send only the created post object back to `PostsPage`
- return full post info from the backend create API
- update tests for updated response format

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'odoo')*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cc8909ee0832989d1764412403143