### PR TITLE
Fix author_id field reference in views

### DIFF
--- a/views/intranet_post_views.xml
+++ b/views/intranet_post_views.xml
@@ -6,7 +6,8 @@
         <field name="arch" type="xml">
             <tree string="Publications">
                 <field name="name"/>
-                <field name="user_id"/>
+                <!-- Use alias field 'author_id' to avoid view errors -->
+                <field name="author_id"/>
                 <field name="department_id" optional="show"/>
                 <field name="create_date"/>
             </tree>
@@ -21,7 +22,8 @@
                 <sheet>
                     <group>
                         <field name="name"/>
-                        <field name="user_id" readonly="1"/>
+                        <!-- Display author information via alias field -->
+                        <field name="author_id" readonly="1"/>
                         <field name="department_id"/>
                         <field name="post_type"/>
                         <field name="active"/>


### PR DESCRIPTION
## Summary
- fix reference to `author_id` in intranet post tree and form views

## Testing
- `pytest -q` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'Image')*

------
https://chatgpt.com/codex/tasks/task_e_686d41fc330c8329be996ea74693f92c