### PR TITLE
Fix useOdooBus call in ChatPage

### DIFF
--- a/patrimoine-mtnd/src/pages/chat/ChatPage.jsx
+++ b/patrimoine-mtnd/src/pages/chat/ChatPage.jsx
@@ -56,7 +56,8 @@ export default function ChatPage() {
         loadConversations()
     }
 
-    useOdooBus("chat_channel", handleNewMessage)
+    // Listen for new chat messages in real time
+    useOdooBus(handleNewMessage)
 
     const startConversation = async emp => {
         if (!emp.user_id) {


### PR DESCRIPTION
## Summary
- update ChatPage to call `useOdooBus` with a single callback

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e1f0d88a08329b08bb2626bead050