### PR TITLE
Exclude current user from conversation names

### DIFF
--- a/controllers/chat_controller.py
+++ b/controllers/chat_controller.py
@@ -19,10 +19,14 @@ class ChatController(http.Controller):
         result = []
         for conv in conversations:
             last_message = conv.message_ids[-1] if conv.message_ids else False
+            other_partners = conv.participant_ids.filtered(
+                lambda u: u.id != user.id
+            )
+            conv_name = conv.name or ", ".join(other_partners.mapped("name"))
             result.append(
                 {
                     "id": conv.id,
-                    "name": conv.name or ", ".join(conv.participant_ids.mapped("name")),
+                    "name": conv_name,
                     "last_message": (
                         last_message.body if last_message else "Aucun message"
                     ),
@@ -139,9 +143,11 @@ class ChatController(http.Controller):
                 .create({"participant_ids": [(6, 0, list(set(participant_ids)))]})
             )
 
+        other_partners = conv.participant_ids.filtered(lambda u: u.id != user.id)
+        conv_name = conv.name or ", ".join(other_partners.mapped("name"))
         result = {
             "id": conv.id,
-            "name": conv.name or ", ".join(conv.participant_ids.mapped("name")),
+            "name": conv_name,
             "last_message": False,
             "last_date": False,
         }

--- a/tests/test_chat_controller.py
+++ b/tests/test_chat_controller.py
@@ -49,7 +49,10 @@ class ChatControllerTest(unittest.TestCase):
         env.__getitem__.return_value = conv_model
         conv_model.sudo.return_value = conv_model
         conv_record = MagicMock(id=5)
+        conv_record.participant_ids = MagicMock()
         conv_record.participant_ids.ids = [1, 2]
+        conv_record.participant_ids.filtered.return_value = conv_record.participant_ids
+        conv_record.participant_ids.mapped.return_value = ["u1", "u2"]
         conv_model.search.return_value = [conv_record]
         mock_request.env = env
         mock_request.env.user.id = 1
@@ -67,7 +70,10 @@ class ChatControllerTest(unittest.TestCase):
         env.__getitem__.return_value = conv_model
         conv_model.sudo.return_value = conv_model
         conv_model.search.return_value = []
-        new_conv = MagicMock(id=7, participant_ids=MagicMock(mapped=lambda x: ['u1','u2']))
+        new_conv_partners = MagicMock()
+        new_conv_partners.filtered.return_value = new_conv_partners
+        new_conv_partners.mapped.return_value = ["u1", "u2"]
+        new_conv = MagicMock(id=7, participant_ids=new_conv_partners)
         conv_model.create.return_value = new_conv
         mock_request.env = env
         mock_request.env.user.id = 1


### PR DESCRIPTION
## Summary
- filter `request.env.user` when building conversation names so the current user's name is omitted
- adjust tests to account for `filtered` and `mapped` partner calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e1f1142e88329b5b96df2a8076c3c