### PR TITLE
Add @api.model_create_multi to ChatMessage

### DIFF
--- a/models/chat.py
+++ b/models/chat.py
@@ -1,4 +1,4 @@
-from odoo import models, fields
+from odoo import models, fields, api
 
 class ChatConversation(models.Model):
     _name = "chat.conversation"
@@ -30,6 +30,7 @@ class ChatMessage(models.Model):
     body = fields.Text(string="Contenu", required=True)
     date = fields.Datetime(string="Date", default=fields.Datetime.now)
 
+    @api.model_create_multi
     def create(self, vals_list):
         """Create messages and notify participants on the bus."""
         messages = super().create(vals_list)

--- a/tests/test_chat_notification.py
+++ b/tests/test_chat_notification.py
@@ -27,10 +27,12 @@ odoo.fields = types.SimpleNamespace(
     Binary=MagicMock(),
     Json=MagicMock(),
 )
+odoo.api = types.SimpleNamespace(model_create_multi=lambda f: f)
 odoo._ = lambda x: x
 sys.modules['odoo'] = odoo
 sys.modules['odoo.models'] = odoo.models
 sys.modules['odoo.fields'] = odoo.fields
+sys.modules['odoo.api'] = odoo.api
 
 import importlib.util
 


### PR DESCRIPTION
## Summary
- add missing `api` import
- decorate `ChatMessage.create` with `@api.model_create_multi`
- stub `odoo.api` in unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e2df0f344832992483a7e762ec2e7