### PR TITLE
Fix bus payload for chat messages

### DIFF
--- a/controllers/chat_controller.py
+++ b/controllers/chat_controller.py
@@ -99,6 +99,7 @@ class ChatController(http.Controller):
 
         channel = f"chat_channel_{conv_id}"
         message_data = {
+            "type": "chat_message",
             "id": msg.id,
             "sender_id": msg.sender_id.id,
             "sender_name": msg.sender_id.name,
@@ -106,7 +107,7 @@ class ChatController(http.Controller):
             "date": msg.create_date,
             "conversation_id": conv.id,
         }
-        request.env["bus.bus"]._sendone(channel, "new_message", message_data)
+        request.env["bus.bus"]._sendone(channel, message_data)
 
         return {"status": "success", "message_id": msg.id}
 

--- a/models/chat.py
+++ b/models/chat.py
@@ -41,6 +41,7 @@ class ChatMessage(models.Model):
         for message in messages:
             participants = message.conversation_id.participant_ids
             payload = {
+                'type': 'chat_message',
                 'id': message.id,
                 'author_name': message.sender_id.name,
                 'content': message.body,

--- a/tests/test_chat_notification.py
+++ b/tests/test_chat_notification.py
@@ -67,6 +67,8 @@ class ChatMessageNotificationTest(unittest.TestCase):
         with patch('models.chat.models.Model.create', return_value=[fake_record]):
             chat.ChatMessage.create(fake_self, [{'conversation_id': 1, 'body': 'hi'}])
         fake_bus.sendmany.assert_called_once()
+        args, _ = fake_bus.sendmany.call_args
+        self.assertEqual(args[0][0][1]['type'], 'chat_message')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- include a `type` field in chat bus payloads
- adjust chat controller to send message payload directly
- check payload type in unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e4a108b308329b3fcffa1d411cc1a