### PR TITLE
Add built asset integration

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -31,7 +31,12 @@
         "reports/report_patrimoine_templates.xml",
         "reports/report_patrimoine.xml",
     ],
-    'assets': {},
+    'assets': {
+        'web.assets_frontend': [
+            'gestion_patrimoine/patrimoine-mtnd/dist/assets/*.js',
+            'gestion_patrimoine/patrimoine-mtnd/dist/assets/*.css',
+        ],
+    },
     'installable': True,
     'application': True,
     'license': 'LGPL-3',

--- a/patrimoine-mtnd/README.md
+++ b/patrimoine-mtnd/README.md
@@ -24,6 +24,20 @@ npm run build
 
 Assurez-vous qu'un serveur Odoo configuré avec le module **gestion_patrimoine** tourne sur le même hôte afin que les requêtes API soient résolues correctement.
 
+## Intégration avec Odoo
+
+Avant d'installer le module Odoo, compilez l'application front‑end afin de
+générer les fichiers JavaScript et CSS référencés dans `__manifest__.py`.
+
+```bash
+npm install
+npm run build
+```
+
+Les ressources produites se trouvent dans le dossier `dist/` et seront servies
+par Odoo via les bundles d'actifs. Exécutez de nouveau cette commande après toute
+mise à jour du code React.
+
 
 ## Exécution des tests
 


### PR DESCRIPTION
## Summary
- link compiled assets from React app in `__manifest__.py`
- describe how to build assets before installing the module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e5284587c8329991a39f0a4179bf0