### PR TITLE
Fix longpolling proxy duplication

### DIFF
--- a/patrimoine-mtnd/vite.config.js
+++ b/patrimoine-mtnd/vite.config.js
@@ -30,12 +30,6 @@ export default defineConfig({
                 changeOrigin: true, // Essentiel
                 secure: false, // Important
             },
-            // --- RÈGLE AJOUTÉE POUR LE TEMPS RÉEL ---
-            "/longpolling": {
-                target: 'http://localhost:8069', // Cible le même serveur Odoo
-                changeOrigin: true,
-                secure: false,
-            },
             // La règle pour les websockets peut rester la même
             "/websocket": {
                 target: "ws://localhost:8072",


### PR DESCRIPTION
## Summary
- remove duplicate `/longpolling` proxy definition in `vite.config.js`

## Testing
- `npm run build` *(fails: vite not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686e5e09d8988329b316e9463d3a2f22