### PR TITLE
Make frontend database configurable

### DIFF
--- a/patrimoine-mtnd/README.md
+++ b/patrimoine-mtnd/README.md
@@ -14,7 +14,18 @@ npm install
 npm run dev
 ```
 
+
 Le serveur de développement utilise un proxy afin de communiquer avec Odoo. Les routes `/api`, `/web`, `/websocket` ainsi que `/longpolling` sont redirigées vers les ports locaux d'Odoo. Pour `/longpolling`, la cible est `http://localhost:8072` et les options `changeOrigin` et `secure` correspondent aux autres règles.
+
+## Configuration de la base de données
+
+Par défaut, l'application se connecte à la base **odoo17_2**. Vous pouvez personnaliser ce nom en créant un fichier `.env` à la racine du projet et en définissant la variable `VITE_ODOO_DB` :
+
+```bash
+echo "VITE_ODOO_DB=ma_base_odoo" > .env
+```
+
+Si aucune valeur n'est spécifiée, la valeur `odoo17_2` sera utilisée automatiquement.
 
 ## Construction pour la production
 

--- a/patrimoine-mtnd/src/auth/authService.ts
+++ b/patrimoine-mtnd/src/auth/authService.ts
@@ -1,5 +1,10 @@
 import { useState, useEffect } from 'react';
 
+// Nom de la base de données Odoo. Peut être configuré via la variable
+// d'environnement VITE_ODOO_DB. Si elle n'est pas définie, on utilise
+// "odoo17_2" par défaut pour conserver un comportement compatible.
+const ODOO_DB = import.meta.env.VITE_ODOO_DB || 'odoo17_2';
+
 
 // Interface pour la réponse de notre nouvelle route /api/users/me
 interface UserInfoResponse {
@@ -52,7 +57,7 @@ export const login = async (
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         jsonrpc: '2.0',
-        params: { db: 'odoo17_2', login: email, password: password },
+        params: { db: ODOO_DB, login: email, password: password },
       }),
       credentials: 'include',
     });

--- a/patrimoine-mtnd/src/context/AuthContext.tsx
+++ b/patrimoine-mtnd/src/context/AuthContext.tsx
@@ -4,6 +4,11 @@ import { useNavigate } from "react-router-dom"
 
 const API_PREFIX = "/web"
 
+// Nom de la base de données Odoo pour l'authentification. Peut être défini via
+// la variable d'environnement VITE_ODOO_DB; "odoo17_2" est utilisé par défaut
+// si elle est absente.
+const ODOO_DB = import.meta.env.VITE_ODOO_DB || "odoo17_2"
+
 // On ajoute les champs optionnels pour le département à l'interface User
 export interface User {
     id: number
@@ -54,7 +59,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                     params: {
                         login: email,
                         password: password,
-                        db: "odoo17_2",
+                        db: ODOO_DB,
                     },
                 },
                 {


### PR DESCRIPTION
## Summary
- read database name from `VITE_ODOO_DB` in auth service
- apply the same logic in AuthContext
- document how to set `VITE_ODOO_DB` with a fallback to `odoo17_2`

## Testing
- `pytest -q`
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e5e0e9af08329b3d076dbe05614c5