### PR TITLE
hide post form and remove share button

### DIFF
--- a/patrimoine-mtnd/src/components/posts/Post.jsx
+++ b/patrimoine-mtnd/src/components/posts/Post.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react"
 import postsService from "../../services/postsService"
 import chatService from "../../services/chatService"
-import { ThumbsUp, MessageCircle, Share2, MoreHorizontal } from "lucide-react"
+import { ThumbsUp, MessageCircle } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
 
@@ -70,9 +70,7 @@ export default function Post({ post }) {
                         </p>
                     </div>
                 </div>
-                <button className="text-slate-400 hover:text-slate-600 dark:hover:text-white">
-                    <MoreHorizontal size={20} />
-                </button>
+
             </div>
 
             {/* Contenu du post */}
@@ -111,12 +109,7 @@ export default function Post({ post }) {
                 >
                     <MessageCircle size={18} /> Commenter
                 </Button>
-                <Button
-                    variant="ghost"
-                    className="w-full gap-2 font-semibold text-slate-500 dark:text-slate-400"
-                >
-                    <Share2 size={18} /> Partager
-                </Button>
+
             </div>
 
             {showComment && (

--- a/patrimoine-mtnd/src/pages/posts/PostsPage.jsx
+++ b/patrimoine-mtnd/src/pages/posts/PostsPage.jsx
@@ -2,10 +2,12 @@ import React, { useEffect, useState, useCallback } from "react"
 import postsService from "../../services/postsService"
 import CreatePost from "../../components/posts/CreatePost"
 import PostsList from "../../components/posts/PostsList"
+import { Button } from "@/components/ui/button"
 
 export default function PostsPage() {
     const [posts, setPosts] = useState([])
     const [isLoading, setIsLoading] = useState(true)
+    const [showCreate, setShowCreate] = useState(false)
 
     const fetchAndSetPosts = useCallback(async () => {
         try {
@@ -25,6 +27,7 @@ export default function PostsPage() {
     const handlePostCreated = () => {
         // Simplement rafraîchir toute la liste pour voir le nouveau post en haut
         fetchAndSetPosts()
+        setShowCreate(false)
     }
 
     return (
@@ -32,7 +35,13 @@ export default function PostsPage() {
             <h1 className="text-3xl font-bold mb-6 text-white">
                 Fil d'Actualités
             </h1>
-            <CreatePost onCreated={handlePostCreated} />
+            {showCreate ? (
+                <CreatePost onCreated={handlePostCreated} />
+            ) : (
+                <Button className="mb-4" onClick={() => setShowCreate(true)}>
+                    Faire un post
+                </Button>
+            )}
             {isLoading ? (
                 <p className="text-center text-slate-400">
                     Chargement des posts...


### PR DESCRIPTION
## Summary
- clean up Post card actions
- show post creation form only after user clicks "Faire un post"

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e69612b2c83298f1fd69689e98187