### PR TITLE
Ajout du suivi des vues et page admin

### DIFF
--- a/models/post.py
+++ b/models/post.py
@@ -47,10 +47,25 @@ class IntranetPost(models.Model):
     like_ids = fields.One2many(
         "intranet.post.like", "post_id", string="Mentions j'aime"
     )
+    viewer_ids = fields.Many2many(
+        "res.users",
+        "intranet_post_view_rel",
+        "post_id",
+        "user_id",
+        string="Vues",
+    )
+    view_count = fields.Integer(
+        string="Nombre de vues", compute="_compute_view_count", store=True
+    )
     share_ids = fields.One2many(
         "intranet.post.share", "post_id", string="Partages"
     )
     active = fields.Boolean(string="Actif", default=True)
+
+    @api.depends("viewer_ids")
+    def _compute_view_count(self):
+        for post in self:
+            post.view_count = len(post.viewer_ids)
 
 
 class IntranetPostComment(models.Model):

--- a/patrimoine-mtnd/src/components/posts/Post.jsx
+++ b/patrimoine-mtnd/src/components/posts/Post.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useState, useEffect } from "react"
 import postsService from "../../services/postsService"
 import chatService from "../../services/chatService"
 import { ThumbsUp, MessageCircle } from "lucide-react"
@@ -23,6 +23,9 @@ export default function Post({ post }) {
     const [likes, setLikes] = useState(post.like_count || 0)
     const [hasLiked, setHasLiked] = useState(false) // Idéalement, l'API devrait nous dire si l'utilisateur actuel a déjà liké
     const [comments, setComments] = useState(post.comments || [])
+    useEffect(() => {
+        postsService.viewPost(post.id).catch(() => {})
+    }, [post.id])
     const [showComment, setShowComment] = useState(false)
     const [newComment, setNewComment] = useState("")
 
@@ -87,10 +90,11 @@ export default function Post({ post }) {
                 )}
             </div>
 
-            {/* Stats (Likes/Commentaires) */}
+            {/* Stats (Likes/Commentaires/Vues) */}
             <div className="px-4 py-2 flex justify-between items-center text-sm text-slate-500 dark:text-slate-400 border-t border-b border-slate-200 dark:border-slate-700">
                 <span>{likes} J'aime</span>
                 <span>{post.comment_count} Commentaires</span>
+                <span>{post.view_count} Vues</span>
             </div>
 
             {/* Barre d'actions */}

--- a/patrimoine-mtnd/src/services/postsService.js
+++ b/patrimoine-mtnd/src/services/postsService.js
@@ -14,6 +14,9 @@ const createPost = (formData) =>
 const likePost = id =>
   api.post(`/api/intranet/posts/${id}/likes`).then(res => res.data)
 
+const viewPost = id =>
+  api.post(`/api/intranet/posts/${id}/views`).then(res => res.data)
+
 const addComment = (id, content) =>
   api
     .post(`/api/intranet/posts/${id}/comments`, { content })
@@ -23,5 +26,6 @@ export default {
   fetchPosts,
   createPost,
   likePost,
-  addComment
+  addComment,
+  viewPost
 }

--- a/patrimoine-mtnd/src/tests/integration/postsService.test.js
+++ b/patrimoine-mtnd/src/tests/integration/postsService.test.js
@@ -42,4 +42,12 @@ describe('postsService', () => {
     // On garde la version la plus complète et robuste du test
     expect(res).toEqual({ status: 'success', data: { liked: true, like_count: 5 } })
   })
-})
+
+  test('viewPost calls view endpoint', async () => {
+    api.post.mockResolvedValue({ data: { status: 'success', data: { view_count: 4 } } })
+
+    const res = await postsService.viewPost(7)
+
+    expect(api.post).toHaveBeenCalledWith('/api/intranet/posts/7/views')
+    expect(res).toEqual({ status: 'success', data: { view_count: 4 } })
+  })})

--- a/tests/test_post_controller.py
+++ b/tests/test_post_controller.py
@@ -181,6 +181,20 @@ class PostControllerTest(unittest.TestCase):
         self.assertEqual(res.status_code, 400)
         env['intranet.post.comment'].sudo().create.assert_not_called()
 
+    @patch('controllers.post_controller.request')
+    def test_add_view_adds_user(self, mock_request):
+        env = MagicMock()
+        post = MagicMock()
+        post.exists.return_value = True
+        env['intranet.post'].sudo().browse.return_value = post
+        mock_request.env = env
+        mock_request.env.user.id = 8
+
+        res = self.controller.add_view(2)
+
+        post.write.assert_called_with({'viewer_ids': [(4, 8)]})
+        self.assertIn('application/json', res.headers.get('Content-Type'))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Résumé
- traque les utilisateurs ayant vu chaque post
- expose le nombre de vues dans l'API et l'interface React
- ajoute un endpoint pour enregistrer une vue
- crée une page d'administration HTML pour voir et supprimer les posts
- met à jour les tests Python et JavaScript

## Test
- `pytest -q`
- `npm test --silent --prefix patrimoine-mtnd` *(échoue : jest absent)*

------
https://chatgpt.com/codex/tasks/task_e_686e764996948329b99231185fac09eb