### PR TITLE
Fix createPost test headers

### DIFF
--- a/patrimoine-mtnd/src/tests/integration/postsService.test.js
+++ b/patrimoine-mtnd/src/tests/integration/postsService.test.js
@@ -29,7 +29,11 @@ describe('postsService', () => {
 
     const post = await postsService.createPost(fd)
 
-    expect(api.post).toHaveBeenCalledWith('/api/intranet/posts', fd)
+    expect(api.post).toHaveBeenCalledWith(
+      '/api/intranet/posts',
+      fd,
+      { headers: { 'Content-Type': 'multipart/form-data' } }
+    )
     expect(post).toEqual({ status: 'success', data: { id: 2 } })
   })
 
@@ -49,5 +53,4 @@ describe('postsService', () => {
     const res = await postsService.viewPost(7)
 
     expect(api.post).toHaveBeenCalledWith('/api/intranet/posts/7/views')
-    expect(res).toEqual({ status: 'success', data: { view_count: 4 } })
-  })})
+    expect(res).toEqual({ status: 'success', data: { view_count: 4 } })  })})


### PR DESCRIPTION
## Summary
- adjust `createPost` test to expect multipart headers

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e81dfdbd08329b968eed246b58411