### PR TITLE
Implement comments retrieval API and UI

### DIFF
--- a/patrimoine-mtnd/src/services/postsService.js
+++ b/patrimoine-mtnd/src/services/postsService.js
@@ -17,15 +17,19 @@ const likePost = id =>
 const viewPost = id =>
   api.post(`/api/intranet/posts/${id}/views`).then(res => res.data)
 
-const addComment = (id, content) =>
+const addComment = (id, content, parentId = null) =>
   api
-    .post(`/api/intranet/posts/${id}/comments`, { content })
+    .post(`/api/intranet/posts/${id}/comments`, { content, parent_id: parentId })
     .then(res => res.data)
+
+const fetchComments = id =>
+  api.get(`/api/intranet/posts/${id}/comments`).then(res => res.data.data)
 
 export default {
   fetchPosts,
   createPost,
   likePost,
   addComment,
-  viewPost
+  viewPost,
+  fetchComments
 }

--- a/patrimoine-mtnd/src/tests/integration/postsService.test.js
+++ b/patrimoine-mtnd/src/tests/integration/postsService.test.js
@@ -43,7 +43,6 @@ describe('postsService', () => {
     const res = await postsService.likePost(3)
 
     expect(api.post).toHaveBeenCalledWith('/api/intranet/posts/3/likes')
-    // On garde la version la plus complète et robuste du test
     expect(res).toEqual({ status: 'success', data: { liked: true, like_count: 5 } })
   })
 
@@ -52,5 +51,24 @@ describe('postsService', () => {
 
     const res = await postsService.viewPost(7)
 
-    expect(api.post).toHaveBeenCalledWith('/api/intranet/posts/7/views')
-    expect(res).toEqual({ status: 'success', data: { view_count: 4 } })  })})
+    expect(api.post).toHaveBeenCalledWith('/api/intranet/posts/7/views')    expect(res).toEqual({ status: 'success', data: { view_count: 4 } })
+  })
+
+  test('addComment posts data with parent id', async () => {
+    api.post.mockResolvedValue({ data: { status: 'success', data: { id: 10 } } })
+
+    const res = await postsService.addComment(5, 'hi', 1)
+
+    expect(api.post).toHaveBeenCalledWith('/api/intranet/posts/5/comments', { content: 'hi', parent_id: 1 })
+    expect(res).toEqual({ status: 'success', data: { id: 10 } })
+  })
+
+  test('fetchComments retrieves list', async () => {
+    api.get.mockResolvedValue({ data: { status: 'success', data: [{ id: 3 }] } })
+
+    const res = await postsService.fetchComments(9)
+
+    expect(api.get).toHaveBeenCalledWith('/api/intranet/posts/9/comments')
+    expect(res).toEqual([{ id: 3 }])
+  })
+})


### PR DESCRIPTION
## Summary
- implement a GET route to retrieve comments
- update posts service with fetchComments and parent_id support
- adjust `Post.jsx` to show comments in a modal and remove chat logic
- add integration tests for the new service calls
- extend controller tests for posting and fetching comments

## Testing
- `python -m pytest -q tests/test_post_controller.py`
- `npx jest patrimoine-mtnd/src/tests/integration/postsService.test.js` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686ecb1610e08329a2d04fd97fde77e4