### PR TITLE
Fix add_comment route type

### DIFF
--- a/controllers/post_controller.py
+++ b/controllers/post_controller.py
@@ -116,7 +116,7 @@ class IntranetPostController(http.Controller):
             headers=CORS_HEADERS,)
 
     # Garde la version de 'main' pour ajouter des commentaires
-    @http.route('/api/intranet/posts/<int:post_id>/comments', auth='user', type='json', methods=['POST'], csrf=False)
+    @http.route('/api/intranet/posts/<int:post_id>/comments', auth='user', type='http', methods=['POST'], csrf=False)
     @handle_api_errors
     def add_comment(self, post_id, content=None, parent_id=None, **kw):
         content = content or kw.get('content')


### PR DESCRIPTION
## Summary
- change `add_comment` decorator from JSON to HTTP

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68737b1720f88329935f181a66a80cc2