### PR TITLE
Fix comment endpoint JSON handling

### DIFF
--- a/controllers/post_controller.py
+++ b/controllers/post_controller.py
@@ -116,31 +116,12 @@ class IntranetPostController(http.Controller):
             headers=CORS_HEADERS,)
 
     # Garde la version de 'main' pour ajouter des commentaires
-    @http.route('/api/intranet/posts/<int:post_id>/comments', auth='user', type='http', methods=['POST'], csrf=False)
+    @http.route('/api/intranet/posts/<int:post_id>/comments', auth='user', type='json', methods=['POST'], csrf=False)
     @handle_api_errors
     def add_comment(self, post_id, content=None, parent_id=None, **kw):
-        content = content or kw.get('content')
-        parent_id = parent_id or kw.get('parent_id')
-
-        data = None
-        try:
-            data = request.jsonrequest
-        except Exception:
-            data = None
-        if not data:
-            body = getattr(request.httprequest, 'data', None)
-            if body:
-                try:
-                    if isinstance(body, bytes):
-                        body = body.decode('utf-8')
-                    data = json.loads(body or "{}")
-                except Exception:
-                    data = None
-        if not isinstance(data, dict):
-            data = {}
-
-        content = content or data.get('content')
-        parent_id = parent_id or data.get('parent_id')
+        data = request.jsonrequest or {}
+        content = content or kw.get('content') or data.get('content')
+        parent_id = parent_id or kw.get('parent_id') or data.get('parent_id')
 
         if not content:
             raise ValidationError('Comment content is required')

--- a/tests/test_post_controller.py
+++ b/tests/test_post_controller.py
@@ -188,6 +188,7 @@ class PostControllerTest(unittest.TestCase):
         env['intranet.post'].sudo.return_value = post_model
         env['intranet.post.comment'].sudo.return_value = MagicMock()
         mock_request.env = env
+        mock_request.jsonrequest = None
 
         res = self.controller.add_comment(1)
 
@@ -208,6 +209,7 @@ class PostControllerTest(unittest.TestCase):
         comment_model.create.return_value = MagicMock(id=4)
         mock_request.env = env
         mock_request.env.user.id = 9
+        mock_request.jsonrequest = None
 
         res = self.controller.add_comment(2, content='hello')
 
@@ -266,6 +268,7 @@ class PostControllerTest(unittest.TestCase):
         env['intranet.post.comment'].sudo.return_value = comment_model
         mock_request.env = env
         mock_request.env.user.id = 9
+        mock_request.jsonrequest = None
 
         self.controller.add_comment(1, content='child', parent_id=5)
 


### PR DESCRIPTION
## Summary
- simplify request parsing when adding comments
- switch comment route to JSON type
- update tests for new JSON behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687399b0ba808329855e00e73f875d75