### PR TITLE
Refactor API error handler

### DIFF
--- a/controllers/asset_controller.py
+++ b/controllers/asset_controller.py
@@ -8,59 +8,9 @@ from odoo.osv import expression
 from werkzeug.exceptions import BadRequest
 import base64  # Pour encoder/décoder les fichiers
 import logging
-from functools import wraps
+from .common import handle_api_errors, CORS_HEADERS
 
 _logger = logging.getLogger(__name__)
-
-# Headers CORS standard
-CORS_HEADERS = {
-    "Content-Type": "application/json",
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
-    "Access-Control-Allow-Headers": "Origin, Content-Type, X-Auth-Token, X-Openerp-Session-Id",
-    "Access-Control-Allow-Credentials": "true"
-}
-
-def handle_api_errors(f):
-    """Decorator pour standardiser la gestion des erreurs API"""
-    @wraps(f)
-    def wrapper(*args, **kwargs):
-        try:
-            return f(*args, **kwargs)
-        except AccessError as e:
-            _logger.error("AccessError in API: %s", str(e))
-            return Response(
-                json.dumps({
-                    "status": "error",
-                    "code": 403,
-                    "message": str(e)
-                }),
-                status=403,
-                headers=CORS_HEADERS
-            )
-        except ValidationError as e:
-            _logger.error("ValidationError in API: %s", str(e))
-            return Response(
-                json.dumps({
-                    "status": "error",
-                    "code": 400,
-                    "message": str(e)
-                }),
-                status=400,
-                headers=CORS_HEADERS
-            )
-        except Exception as e:
-            _logger.error("Unexpected error in API: %s", str(e))
-            return Response(
-                json.dumps({
-                    "status": "error",
-                    "code": 500,
-                    "message": "Internal server error"
-                }),
-                status=500,
-                headers=CORS_HEADERS
-            )
-    return wrapper
 
 
 class PatrimoineAssetController(http.Controller):

--- a/controllers/chat_controller.py
+++ b/controllers/chat_controller.py
@@ -1,6 +1,9 @@
 from odoo import http
 from odoo.http import request, Response
 import json
+import logging
+
+_logger = logging.getLogger(__name__)
 
 
 class ChatController(http.Controller):

--- a/controllers/common.py
+++ b/controllers/common.py
@@ -1,0 +1,46 @@
+import json
+import logging
+from functools import wraps
+from odoo.exceptions import AccessError, ValidationError
+from odoo.http import Response
+
+CORS_HEADERS = {
+    "Content-Type": "application/json",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+    "Access-Control-Allow-Headers": "Origin, Content-Type, X-Auth-Token, X-Openerp-Session-Id",
+    "Access-Control-Allow-Credentials": "true",
+}
+
+
+def handle_api_errors(func):
+    """Decorator to standardize API error handling."""
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        logger = logging.getLogger(func.__module__)
+        try:
+            return func(*args, **kwargs)
+        except AccessError as e:
+            logger.error("AccessError in API: %s", str(e))
+            return Response(
+                json.dumps({"status": "error", "code": 403, "message": str(e)}),
+                status=403,
+                headers=CORS_HEADERS,
+            )
+        except ValidationError as e:
+            logger.error("ValidationError in API: %s", str(e))
+            return Response(
+                json.dumps({"status": "error", "code": 400, "message": str(e)}),
+                status=400,
+                headers=CORS_HEADERS,
+            )
+        except Exception as e:
+            logger.error("Unexpected error in API: %s", str(e))
+            return Response(
+                json.dumps({"status": "error", "code": 500, "message": "Internal server error"}),
+                status=500,
+                headers=CORS_HEADERS,
+            )
+
+    return wrapper

--- a/controllers/post_controller.py
+++ b/controllers/post_controller.py
@@ -5,8 +5,7 @@ from odoo import http
 from odoo.http import request, Response
 from odoo.exceptions import ValidationError
 
-# Assurez-vous que handle_api_errors est bien importé depuis votre autre contrôleur
-from .asset_controller import handle_api_errors, CORS_HEADERS
+from .common import handle_api_errors, CORS_HEADERS
 
 _logger = logging.getLogger(__name__)
 

--- a/controllers/userApi_controller.py
+++ b/controllers/userApi_controller.py
@@ -1,6 +1,9 @@
 from odoo import http
 from odoo.http import request
 import json
+import logging
+
+_logger = logging.getLogger(__name__)
 
 
 class UserApiController(http.Controller):

--- a/tests/test_asset_controller.py
+++ b/tests/test_asset_controller.py
@@ -73,6 +73,13 @@ controllers_pkg = types.ModuleType('controllers')
 controllers_pkg.__path__ = []
 sys.modules.setdefault('controllers', controllers_pkg)
 
+common_path = os.path.join(os.path.dirname(__file__), '..', 'controllers', 'common.py')
+spec_common = importlib.util.spec_from_file_location('controllers.common', common_path)
+common_module = importlib.util.module_from_spec(spec_common)
+spec_common.loader.exec_module(common_module)
+sys.modules['controllers.common'] = common_module
+controllers_pkg.common = common_module
+
 asset_path = os.path.join(os.path.dirname(__file__), '..', 'controllers', 'asset_controller.py')
 spec = importlib.util.spec_from_file_location('controllers.asset_controller', asset_path)
 asset_controller = importlib.util.module_from_spec(spec)

--- a/tests/test_post_controller.py
+++ b/tests/test_post_controller.py
@@ -60,7 +60,7 @@ sys.modules.setdefault('odoo.models', odoo.models)
 sys.modules.setdefault('odoo.osv', odoo.osv)
 sys.modules.setdefault('odoo.api', odoo.api)
 
-# Stub for external dependency used by asset_controller
+# Stub for external dependencies
 import types as _types
 dateutil = _types.ModuleType('dateutil')
 relativedelta_mod = _types.ModuleType('dateutil.relativedelta')
@@ -80,24 +80,25 @@ import importlib.util
 controllers_pkg = types.ModuleType('controllers')
 controllers_pkg.__path__ = []
 
-# Provide a minimal stub for asset_controller used by post_controller
-asset_controller = types.ModuleType('controllers.asset_controller')
+# Provide a minimal stub for common module used by post_controller
+common_module = types.ModuleType('controllers.common')
+
 def handle_api_errors(func):
     def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except Exception as e:
+        except Exception:
             resp = MagicMock()
             resp.status_code = 400
             return resp
     return wrapper
 
-asset_controller.handle_api_errors = handle_api_errors
-asset_controller.CORS_HEADERS = {}
+common_module.handle_api_errors = handle_api_errors
+common_module.CORS_HEADERS = {}
 
-controllers_pkg.asset_controller = asset_controller
+controllers_pkg.common = common_module
 sys.modules.setdefault('controllers', controllers_pkg)
-sys.modules.setdefault('controllers.asset_controller', asset_controller)
+sys.modules.setdefault('controllers.common', common_module)
 
 post_path = os.path.join(os.path.dirname(__file__), '..', 'controllers', 'post_controller.py')
 spec = importlib.util.spec_from_file_location('controllers.post_controller', post_path)


### PR DESCRIPTION
## Summary
- centralize API error handling in `controllers.common`
- update asset and post controllers to import from `common`
- add module loggers to all controllers
- adjust tests for the new module layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874d08cb6ac8329acf92271b07d6ca5