### PR TITLE
Fix action handling in AdminDeclarationsPerte

### DIFF
--- a/patrimoine-mtnd/src/pages/admin/AdminDeclarationsPerte.jsx
+++ b/patrimoine-mtnd/src/pages/admin/AdminDeclarationsPerte.jsx
@@ -102,10 +102,9 @@ export default function AdminDeclarationsPerte() {
 
     const handleProcess = async (id, action) => {
         try {
-            const status = action === "confirm" ? "approved" : "rejected"
-            await materialService.processPerte(id, status)
+            await materialService.processPerte(id, action)
             toast.success(
-                `Déclaration ${status === "approved" ? "approuvée" : "rejetée"} avec succès.`
+                `Déclaration ${action === "approve" ? "approuvée" : "rejetée"} avec succès.`
             )
             loadDeclarations()
         } catch (err) {
@@ -214,7 +213,7 @@ export default function AdminDeclarationsPerte() {
                                                     onClick={() =>
                                                         handleProcess(
                                                             perte.id,
-                                                            "confirm"
+                                                            "approve"
                                                         )
                                                     }
                                                     className="bg-green-600 hover:bg-green-700"


### PR DESCRIPTION
## Summary
- call `materialService.processPerte` with the given action string
- update UI to send `"approve"` instead of `"confirm"`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875235b68688329ad69e3f411ae9588