### PR TITLE
Add director access to team loss declarations

### DIFF
--- a/security/record_rules.xml
+++ b/security/record_rules.xml
@@ -150,6 +150,21 @@
                 eval="1"/>
         </record>
 
+        <record id="rule_perte_director_access" model="ir.rule">
+            <field name="name">Directeur - Déclarations pertes équipe</field>
+            <field name="model_id" ref="model_patrimoine_perte"/>
+            <field name="groups" eval="[(4, ref('gestion_patrimoine.group_patrimoine_director'))]"/>
+            <field name="domain_force">
+                ['|',
+                 ('declarer_par_id', '=', user.id),
+                 ('declarer_par_id.employee_ids.parent_id.user_id', '=', user.id)
+                ]
+            </field>
+            <field name="perm_read" eval="1"/>
+            <field name="perm_write" eval="1"/>
+            <field name="perm_create" eval="1"/>
+        </record>
+
         <!-- Agent : voit uniquement ses biens affectés -->
         <record id="rule_asset_agent_read"
             model="ir.rule">


### PR DESCRIPTION
## Summary
- allow directors to access and edit team loss declarations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68755d01f268832981dbca7f8c7ef2d4