### PR TITLE
Add debug logs for comment payload

### DIFF
--- a/patrimoine-mtnd/src/services/postsService.js
+++ b/patrimoine-mtnd/src/services/postsService.js
@@ -17,10 +17,12 @@ const likePost = id =>
 const viewPost = id =>
   api.post(`/api/intranet/posts/${id}/views`).then(res => res.data)
 
-const addComment = (id, content, parentId = null) =>
-  api
+const addComment = (id, content, parentId = null) => {
+  console.debug('addComment payload', { id, content, parent_id: parentId })
+  return api
     .post(`/api/intranet/posts/${id}/comments`, { content, parent_id: parentId })
     .then(res => res.data)
+}
 
 const fetchComments = id =>
   api.get(`/api/intranet/posts/${id}/comments`).then(res => res.data.data)


### PR DESCRIPTION
## Summary
- log received data in `add_comment` for easier debugging
- log when comment has been created
- log outgoing payload in React `postsService.addComment`

## Testing
- `pytest -q`
- `npm test --silent` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6875ae7cdee48329b9da086a9d46597b