### PR TITLE
Update manager perte listing and director rule

### DIFF
--- a/controllers/asset_controller.py
+++ b/controllers/asset_controller.py
@@ -2469,16 +2469,24 @@ class PatrimoineAssetController(http.Controller):
                     json.dumps([]), headers={"Content-Type": "application/json"}
                 )
 
-            # On cherche les employés qui ont ce manager (current_employee) comme supérieur
-            team_employee_ids = (
+            # Recherche des employés ayant ce manager comme supérieur hiérarchique
+            employee_ids = (
                 request.env["hr.employee"]
                 .search([("parent_id", "=", current_employee.id)])
                 .ids
             )
 
+            # S'il n'y a pas de subordonnés directs, on récupère les employés du même département
+            if not employee_ids and current_employee.department_id:
+                employee_ids = (
+                    request.env["hr.employee"]
+                    .search([("department_id", "=", current_employee.department_id.id)])
+                    .ids
+                )
+
             # On cherche les déclarations faites par ces employés et qui sont en attente de validation
             domain = [
-                ("declarer_par_id.employee_ids", "in", team_employee_ids),
+                ("declarer_par_id.employee_ids", "in", employee_ids),
                 ("state", "=", "to_approve"),
             ]
 

--- a/security/record_rules.xml
+++ b/security/record_rules.xml
@@ -157,7 +157,7 @@
             <field name="domain_force">
                 ['|',
                  ('declarer_par_id', '=', user.id),
-                 ('declarer_par_id.employee_ids.parent_id.user_id', '=', user.id)
+                 ('declarer_par_id.employee_ids.department_id', '=', user.employee_id.department_id.id)
                 ]
             </field>
             <field name="perm_read" eval="1"/>


### PR DESCRIPTION
## Summary
- broaden manager perte search to include department employees when no direct reports
- allow directors to view losses declared by employees within their department

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876340f952c83299f2f8b4b0d1d2753