### PR TITLE
Configure API base URL

### DIFF
--- a/patrimoine-mtnd/src/services/apiConfig.js
+++ b/patrimoine-mtnd/src/services/apiConfig.js
@@ -1,7 +1,8 @@
 import axios from "axios"
+import { API_BASE_URL } from "@/config/api"
 
 const api = axios.create({
-    baseURL: "",
+    baseURL: API_BASE_URL,
     headers: {
         "Content-Type": "application/json",
         Accept: "application/json",


### PR DESCRIPTION
## Summary
- inject API_BASE_URL into axios instance

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68763414876883299239e7bf81c306ca