### PR TITLE
Add admin posts table

### DIFF
--- a/patrimoine-mtnd/src/App.jsx
+++ b/patrimoine-mtnd/src/App.jsx
@@ -16,6 +16,7 @@ import CategoryItemsPage from './pages/admin/CategoryItemsPage';
 import AdminDemandeMateriel from './pages/admin/AdminDemandesMateriel';
 import AdminMouvement from './pages/admin/AdminMouvement';
 import AdminDeclarationsPerte from './pages/admin/AdminDeclarationsPerte';
+import AdminPostsPage from './pages/admin/AdminPostsPage';
 import AdminStatsPage from './pages/admin/AdminStatsPage';
 import DeclarationPerte from './pages/DeclarationPerte';
 import DirDashboardPage from './pages/director/DirDashboardPage';
@@ -111,6 +112,14 @@ function AppContent() {
                   element={
                       <ProtectedRoute roles={[ROLES.ADMIN]}>
                           <AdminDeclarationsPerte />
+                      </ProtectedRoute>
+                  }
+              />
+              <Route
+                  path="/admin/posts"
+                  element={
+                      <ProtectedRoute roles={[ROLES.ADMIN]}>
+                          <AdminPostsPage />
                       </ProtectedRoute>
                   }
               />

--- a/patrimoine-mtnd/src/components/app-sidebar.tsx
+++ b/patrimoine-mtnd/src/components/app-sidebar.tsx
@@ -108,6 +108,11 @@ export default function AppSidebar({ onCollapseChange }: AppSidebarProps) {
                     label: "Déclarations de Pertes",
                     path: "/admin/pertes",
                 },
+                {
+                    icon: <FileText className="h-5 w-5" />,
+                    label: "Posts (admin)",
+                    path: "/admin/posts",
+                },
             ],
         }] : []),
         ...(hasRole('director') ? [{

--- a/patrimoine-mtnd/src/pages/admin/AdminPostsPage.jsx
+++ b/patrimoine-mtnd/src/pages/admin/AdminPostsPage.jsx
@@ -1,0 +1,120 @@
+import React, { useEffect, useState, useRef } from "react"
+import postsService from "@/services/postsService"
+import { Button } from "@/components/ui/button"
+import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from "@/components/ui/table"
+import { Printer } from "lucide-react"
+import { toast } from "react-hot-toast"
+
+export default function AdminPostsPage() {
+    const [posts, setPosts] = useState([])
+    const [loading, setLoading] = useState(true)
+    const [error, setError] = useState(null)
+    const tableRef = useRef()
+
+    const loadPosts = () => {
+        setLoading(true)
+        postsService
+            .fetchPosts()
+            .then(data => setPosts(Array.isArray(data) ? data : []))
+            .catch(err => {
+                console.error(err)
+                setError("Erreur de chargement des posts.")
+            })
+            .finally(() => setLoading(false))
+    }
+
+    useEffect(loadPosts, [])
+
+    const handleDelete = async id => {
+        try {
+            await postsService.deletePost(id)
+            toast.success("Post supprimé")
+            loadPosts()
+        } catch (err) {
+            console.error(err)
+            toast.error("Échec de la suppression")
+        }
+    }
+
+    const handlePrint = () => {
+        const content = tableRef.current
+        if (!content) return
+        const w = window.open("", "_blank", "height=800,width=1000")
+        w.document.write("<html><head><title>Liste des Posts</title>")
+        Array.from(document.querySelectorAll('link[rel="stylesheet"], style')).forEach(link => {
+            w.document.head.appendChild(link.cloneNode(true))
+        })
+        w.document.write(`
+            <style>
+                body { padding: 20px; font-family: Arial, sans-serif; }
+                table { width: 100%; border-collapse: collapse; }
+                th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }
+                th { background-color: #f2f2f2; }
+                .no-print { display: none !important; }
+            </style>
+        `)
+        w.document.write("</head><body>")
+        w.document.write(`<div class='print-only:block'><h2>Liste des Posts</h2><p>Imprimé le ${new Date().toLocaleDateString('fr-FR')}</p></div>`)
+        w.document.write(content.innerHTML)
+        w.document.write("</body></html>")
+        w.document.close()
+        setTimeout(() => {
+            w.focus()
+            w.print()
+            w.close()
+        }, 500)
+    }
+
+    if (loading) return <div className="p-8 text-center">Chargement...</div>
+    if (error) return <div className="p-8 text-center text-red-500">{error}</div>
+
+    return (
+        <div className="min-h-screen w-full">
+            <h1 className="text-5xl mb-10 text-center font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-blue-400 via-purple-500 to-pink-500">
+                Gestion des Posts
+            </h1>
+            <Button onClick={handlePrint} variant="outline" className="hover:bg-orange-500 hover:text-white">
+                <Printer className="h-4 w-4 mr-2" />
+                Imprimer le tableau
+            </Button>
+            <div ref={tableRef} className="rounded-md border mt-4">
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead>Titre</TableHead>
+                            <TableHead>Auteur</TableHead>
+                            <TableHead>Date</TableHead>
+                            <TableHead className="text-right no-print">Actions</TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {posts.length > 0 ? (
+                            posts.map(p => (
+                                <TableRow key={p.id}>
+                                    <TableCell className="font-medium">{p.title}</TableCell>
+                                    <TableCell>{p.author}</TableCell>
+                                    <TableCell>{new Date(p.create_date).toLocaleDateString()}</TableCell>
+                                    <TableCell className="text-right space-x-2 no-print">
+                                        <Button variant="outline" size="sm" asChild>
+                                            <a href={`/web#id=${p.id}&model=intranet.post&view_type=form`} target="_blank" rel="noopener noreferrer">Voir</a>
+                                        </Button>
+                                        <Button variant="destructive" size="sm" onClick={() => handleDelete(p.id)}>
+                                            Supprimer
+                                        </Button>
+                                    </TableCell>
+                                </TableRow>
+                            ))
+                        ) : (
+                            <TableRow>
+                                <TableCell colSpan="4" className="h-24 text-center">
+                                    Aucun post trouvé.
+                                </TableCell>
+                            </TableRow>
+                        )}
+                    </TableBody>
+                </Table>
+            </div>
+        </div>
+    )
+}
+

--- a/patrimoine-mtnd/src/services/postsService.js
+++ b/patrimoine-mtnd/src/services/postsService.js
@@ -27,11 +27,15 @@ const addComment = (id, content, parentId = null) => {
 const fetchComments = id =>
   api.get(`/api/intranet/posts/${id}/comments`).then(res => res.data.data)
 
+const deletePost = id =>
+  api.get(`/admin/posts/${id}/delete`)
+
 export default {
   fetchPosts,
   createPost,
   likePost,
   addComment,
   viewPost,
-  fetchComments
+  fetchComments,
+  deletePost
 }

--- a/patrimoine-mtnd/src/tests/integration/postsService.test.js
+++ b/patrimoine-mtnd/src/tests/integration/postsService.test.js
@@ -71,4 +71,12 @@ describe('postsService', () => {
     expect(api.get).toHaveBeenCalledWith('/api/intranet/posts/9/comments')
     expect(res).toEqual([{ id: 3 }])
   })
+
+  test('deletePost calls admin delete route', async () => {
+    api.get.mockResolvedValue({})
+
+    await postsService.deletePost(12)
+
+    expect(api.get).toHaveBeenCalledWith('/admin/posts/12/delete')
+  })
 })


### PR DESCRIPTION
## Summary
- list all posts in new AdminPostsPage with print/export and delete
- expose `deletePost` API helper
- add AdminPostsPage route and menu link
- cover new service call in tests

## Testing
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6876398fd2dc8329a619a50f361596ce