### PR TITLE
Fix redirect to agent dashboard

### DIFF
--- a/patrimoine-mtnd/src/pages/DeclarationPerte.jsx
+++ b/patrimoine-mtnd/src/pages/DeclarationPerte.jsx
@@ -110,7 +110,7 @@ export default function DeclarationPerte() {
             toast.success(
                 "Déclaration de perte soumise avec succès pour validation."
             )
-            navigate("/dashboard-agent")
+            navigate("/agent")
         } catch (error) {
             toast.error(`Erreur lors de la soumission : ${error.message}`)
         } finally {


### PR DESCRIPTION
## Summary
- ensure the loss declaration page redirects to the existing `/agent` route

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68769176fba48329b578069f7f53dd0b