### PR TITLE
Add cancel button to perte declaration page

### DIFF
--- a/patrimoine-mtnd/src/pages/DeclarationPerte.jsx
+++ b/patrimoine-mtnd/src/pages/DeclarationPerte.jsx
@@ -306,7 +306,14 @@ export default function DeclarationPerte() {
                                 )}
                             </div>
 
-                            <div className="pt-4 flex justify-end">
+                            <div className="pt-4 flex justify-end space-x-4">
+                                <Button
+                                    type="button"
+                                    onClick={() => navigate(-1)}
+                                    variant="outline"
+                                >
+                                    Annuler
+                                </Button>
                                 <Button
                                     type="submit"
                                     disabled={isLoading}


### PR DESCRIPTION
## Summary
- add cancel button in DeclarationPerte page

## Testing
- `pytest -q`
- `npm test --silent --prefix patrimoine-mtnd` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876917a9ce8832993f56470e0586a89