### PR TITLE
Fix action order in perte view

### DIFF
--- a/views/perte_views.xml
+++ b/views/perte_views.xml
@@ -14,6 +14,13 @@
         </field>
     </record>
 
+    <record id="action_perte_my" model="ir.actions.act_window">
+        <field name="name">Mes déclarations</field>
+        <field name="res_model">patrimoine.perte</field>
+        <field name="view_mode">tree,form</field>
+        <field name="domain">[("declarer_par_id", "=", uid)]</field>
+    </record>
+
     <record id="view_perte_form" model="ir.ui.view">
         <field name="name">patrimoine.perte.form</field>
         <field name="model">patrimoine.perte</field>
@@ -46,13 +53,6 @@
         <field name="name">Déclarations de perte</field>
         <field name="res_model">patrimoine.perte</field>
         <field name="view_mode">tree,form</field>
-    </record>
-
-    <record id="action_perte_my" model="ir.actions.act_window">
-        <field name="name">Mes déclarations</field>
-        <field name="res_model">patrimoine.perte</field>
-        <field name="view_mode">tree,form</field>
-        <field name="domain">[("declarer_par_id", "=", uid)]</field>
     </record>
 
     <!-- Menu principal -->


### PR DESCRIPTION
## Summary
- reorder `action_perte_my` before the form view to avoid external ID load error

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68775ea8d4a8832985a182b7687167d0