### PR TITLE
Add in-app chat page to test websockets

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -28,10 +28,17 @@
         "views/asset_category_views.xml",
         "views/asset_custom_field_views.xml",
         "views/asset_subcategory_views.xml",
+        "views/chat_page_views.xml",
         "views/chat_test_views.xml",
         "reports/report_patrimoine_templates.xml",
         "reports/report_patrimoine.xml",
     ],
+    "assets": {
+        "web.assets_backend": [
+            "gestion_patrimoine/static/src/js/chat_page.js",
+            "gestion_patrimoine/static/src/css/chat.css",
+        ],
+    },
     "installable": True,
     "application": True,
     "license": "LGPL-3",

--- a/controllers/chat_controller.py
+++ b/controllers/chat_controller.py
@@ -183,3 +183,8 @@ class ChatController(http.Controller):
             "last_date": False,
         }
         return {"status": "success", "data": result}
+
+    @http.route('/intranet/chat', auth='user', type='http', website=True)
+    def chat_page(self, **kwargs):
+        """Simple page to test the real time chat inside Odoo."""
+        return request.render('gestion_patrimoine.chat_page_template')

--- a/static/src/css/chat.css
+++ b/static/src/css/chat.css
@@ -1,0 +1,19 @@
+#gp-chat-app {height: calc(100vh - 5rem); background:#1f2937; color:#fff; display:flex; overflow:hidden;}
+#gp-conversations {width:33%; border-right:1px solid #374151; display:flex; flex-direction:column;}
+#gp-conversations .conv-header {padding:1rem; border-bottom:1px solid #374151; display:flex; justify-content:space-between; align-items:center;}
+#gp-conversation-items {flex:1; overflow-y:auto;}
+#gp-conversation-items .conv-item {padding:0.75rem; border-bottom:1px solid #374151; cursor:pointer;}
+#gp-conversation-items .conv-item:hover {background:#374151;}
+#gp-conversation-items .conv-item.active {background:#111827;}
+#gp-chat-view {flex:1; display:flex; flex-direction:column;}
+#gp-message-list {flex:1; overflow-y:auto; padding:1rem;}
+#gp-message-list .msg-author {color:#93c5fd; font-weight:600;}
+#gp-send-area {display:flex; border-top:1px solid #374151; padding:0.5rem;}
+#gp-send-area input {flex:1; background:#1f2937; color:#fff; border:1px solid #374151; border-radius:4px; padding:0.5rem; margin-right:0.5rem;}
+#gp-send-area button {background:#3b82f6; color:#fff; border:none; padding:0.5rem 1rem; border-radius:4px;}
+#gp-employee-list {position:fixed; inset:0; background:rgba(0,0,0,0.5); display:none; align-items:center; justify-content:center; z-index:10;}
+#gp-employee-list .gp-employee-wrapper {background:#1f2937; padding:1rem; border-radius:6px; max-height:80vh; overflow-y:auto; width:20rem;}
+#gp-employee-list ul {list-style:none; padding:0; margin:0;}
+#gp-employee-list li {padding:0.5rem; cursor:pointer;}
+#gp-employee-list li:hover {background:#374151;}
+#gp-employee-list button {margin-top:0.5rem; color:#d1d5db; background:none; border:none; cursor:pointer;}

--- a/static/src/js/chat_page.js
+++ b/static/src/js/chat_page.js
@@ -1,0 +1,145 @@
+(function () {
+  const ODOO_WS_URL = `ws://${window.location.host}/websocket`;
+  let socket;
+  let conversations = [];
+  let activeConversation = null;
+  const subscribed = new Set();
+
+  async function fetchJson(url, opts = {}) {
+    const resp = await fetch(url, {
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      ...opts,
+    });
+    return resp.json();
+  }
+
+  async function loadConversations() {
+    conversations = await fetchJson('/api/chat/conversations');
+    const container = document.getElementById('gp-conversation-items');
+    container.innerHTML = '';
+    conversations.forEach((c) => {
+      const div = document.createElement('div');
+      div.className = 'conv-item' + (activeConversation && activeConversation.id === c.id ? ' active' : '');
+      div.textContent = c.name;
+      div.onclick = () => selectConversation(c);
+      container.appendChild(div);
+    });
+  }
+
+  async function selectConversation(conv) {
+    activeConversation = conv;
+    await loadMessages();
+    loadConversations();
+  }
+
+  async function loadMessages() {
+    if (!activeConversation) return;
+    const res = await fetchJson(`/api/chat/conversations/${activeConversation.id}/messages`);
+    const list = document.getElementById('gp-message-list');
+    list.innerHTML = '';
+    const msgs = res.data || [];
+    msgs.forEach((m) => {
+      const wrap = document.createElement('div');
+      wrap.className = 'msg';
+      const author = document.createElement('span');
+      author.className = 'msg-author';
+      author.textContent = m.author_name;
+      const content = document.createElement('span');
+      content.textContent = m.content;
+      wrap.appendChild(author);
+      wrap.appendChild(document.createElement('br'));
+      wrap.appendChild(content);
+      list.appendChild(wrap);
+    });
+    list.scrollTop = list.scrollHeight;
+  }
+
+  async function sendCurrent() {
+    const input = document.getElementById('gp-message-input');
+    const text = input.value.trim();
+    if (!text || !activeConversation) return;
+    await fetchJson(`/api/chat/conversations/${activeConversation.id}/messages`, {
+      method: 'POST',
+      body: JSON.stringify({ content: text }),
+    });
+    input.value = '';
+    await loadMessages();
+  }
+
+  function connectWebSocket() {
+    if (socket) return;
+    socket = new WebSocket(ODOO_WS_URL);
+    socket.onopen = () => {
+      conversations.forEach((c) => subscribe(`chat_channel_${c.id}`));
+    };
+    socket.onmessage = (ev) => {
+      try {
+        const data = JSON.parse(ev.data);
+        if (data.type === 'new_message' && data.payload) {
+          const msg = data.payload;
+          if (activeConversation && msg.conversation_id === activeConversation.id) {
+            loadMessages();
+          }
+        }
+      } catch (e) {
+        console.error('ws message', e);
+      }
+    };
+  }
+
+  function subscribe(channel) {
+    if (!socket || socket.readyState !== WebSocket.OPEN || subscribed.has(channel)) return;
+    socket.send(JSON.stringify({ event_name: 'subscribe', channels: [channel], last: 0 }));
+    subscribed.add(channel);
+  }
+
+  async function showEmployeeList() {
+    const list = document.getElementById('gp-employee-list');
+    const ul = document.getElementById('gp-employee-items');
+    ul.innerHTML = '';
+    list.style.display = 'flex';
+    const employees = await fetchJson('/api/patrimoine/employees');
+    employees.forEach((emp) => {
+      if (!emp.user_id) return;
+      const li = document.createElement('li');
+      li.textContent = emp.name;
+      li.onclick = () => createConversation(emp.id);
+      ul.appendChild(li);
+    });
+  }
+
+  async function createConversation(empId) {
+    await fetchJson('/api/chat/conversations', {
+      method: 'POST',
+      body: JSON.stringify({ participants: [empId] }),
+    });
+    document.getElementById('gp-employee-list').style.display = 'none';
+    await loadConversations();
+  }
+
+  function initEvents() {
+    document.getElementById('gp-send-button').addEventListener('click', sendCurrent);
+    document.getElementById('gp-message-input').addEventListener('keypress', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        sendCurrent();
+      }
+    });
+    document.getElementById('gp-new-conversation').addEventListener('click', showEmployeeList);
+    document.getElementById('gp-employee-close').addEventListener('click', () => {
+      document.getElementById('gp-employee-list').style.display = 'none';
+    });
+  }
+
+  async function init() {
+    await loadConversations();
+    if (conversations.length) {
+      selectConversation(conversations[0]);
+    }
+    connectWebSocket();
+    initEvents();
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
+})();

--- a/views/chat_page_views.xml
+++ b/views/chat_page_views.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="chat_page_template" name="Intranet Chat Page">
+        <t t-call="web.layout">
+            <t t-set="title">Chat Intranet</t>
+            <div id="gp-chat-app">
+                <div id="gp-conversations">
+                    <div class="conv-header">
+                        <h2>Conversations</h2>
+                        <button type="button" id="gp-new-conversation">Nouveau</button>
+                    </div>
+                    <div id="gp-conversation-items"></div>
+                </div>
+                <div id="gp-chat-view">
+                    <div id="gp-message-list"></div>
+                    <div id="gp-send-area">
+                        <input id="gp-message-input" type="text" placeholder="Tapez un message..."/>
+                        <button type="button" id="gp-send-button">Envoyer</button>
+                    </div>
+                </div>
+                <div id="gp-employee-list">
+                    <div class="gp-employee-wrapper">
+                        <h2>Choisir un employé</h2>
+                        <ul id="gp-employee-items"></ul>
+                        <button type="button" id="gp-employee-close">Fermer</button>
+                    </div>
+                </div>
+            </div>
+            <link rel="stylesheet" href="/gestion_patrimoine/static/src/css/chat.css"/>
+            <script type="text/javascript" src="/gestion_patrimoine/static/src/js/chat_page.js"></script>
+        </t>
+    </template>
+
+    <record id="action_chat_page" model="ir.actions.act_url">
+        <field name="name">Chat</field>
+        <field name="target">self</field>
+        <field name="url">/intranet/chat</field>
+    </record>
+
+    <menuitem id="menu_intranet_chat" name="Chat" parent="menu_patrimoine_root" sequence="45" action="action_chat_page"/>
+</odoo>


### PR DESCRIPTION
## Summary
- add new chat page assets and template for Odoo
- expose `/intranet/chat` route to render the page
- register assets and menu entry in module manifest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877673f4d608329bd845c624a381550