### PR TITLE
Fix TypeError in chat_page.js when loaded globally

### DIFF
--- a/static/src/js/chat_page.js
+++ b/static/src/js/chat_page.js
@@ -15,8 +15,11 @@
   }
 
   async function loadConversations() {
-    conversations = await fetchJson('/api/chat/conversations');
     const container = document.getElementById('gp-conversation-items');
+    if (!container) {
+      return;
+    }
+    conversations = await fetchJson('/api/chat/conversations');
     container.innerHTML = '';
     conversations.forEach((c) => {
       const div = document.createElement('div');
@@ -133,6 +136,9 @@
   }
 
   async function init() {
+    if (!document.getElementById('gp-chat-app')) {
+      return;
+    }
     await loadConversations();
     if (conversations.length) {
       selectConversation(conversations[0]);


### PR DESCRIPTION
## Summary
- avoid calling `loadConversations` when the conversation container is missing
- skip chat page initialization if the chat app element isn't present

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68776c19d8bc8329ad32c3ba23e80c99