### PR TITLE
Refactor image tags to ApiImage

### DIFF
--- a/patrimoine-mtnd/src/components/posts/Post.jsx
+++ b/patrimoine-mtnd/src/components/posts/Post.jsx
@@ -3,6 +3,7 @@ import postsService from "../../services/postsService"
 import { ThumbsUp, MessageCircle } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
+import ApiImage from "@/components/ui/ApiImage"
 
 // Fonction pour formater la date
 const formatDate = dateString => {
@@ -99,7 +100,7 @@ export default function Post({ post }) {
                     {post.body}
                 </p>
                 {post.image && (
-                    <img
+                    <ApiImage
                         src={`http://localhost${post.image}`}
                         alt="Image du post"
                         className="w-full rounded-lg border border-slate-200 dark:border-slate-700"

--- a/patrimoine-mtnd/src/pages/admin/AdminMaterialTypes.jsx
+++ b/patrimoine-mtnd/src/pages/admin/AdminMaterialTypes.jsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "react-router-dom"
+import ApiImage from "@/components/ui/ApiImage"
 
 export default function AdminMaterialTypes() {
     const navigate = useNavigate()
@@ -42,7 +43,7 @@ export default function AdminMaterialTypes() {
                         onClick={() => navigate(type.route)}
                         className="relative rounded-3xl overflow-hidden shadow-lg hover:shadow-2xl transform hover:-translate-y-2 transition-all duration-300 cursor-pointer"
                     >
-                        <img
+                        <ApiImage
                             src={type.image}
                             alt={type.name}
                             className="w-full h-80 object-cover brightness-110 contrast-110 saturate-125 transition-transform duration-700 group-hover:scale-105"

--- a/patrimoine-mtnd/src/pages/admin/CategoryItemsPage.jsx
+++ b/patrimoine-mtnd/src/pages/admin/CategoryItemsPage.jsx
@@ -8,7 +8,8 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { toast } from "react-hot-toast"
 import { Search, PlusCircle, Calendar, MapPin, Euro } from "lucide-react";
-import materialService from "@/services/materialService"; 
+import materialService from "@/services/materialService";
+import ApiImage from "@/components/ui/ApiImage";
 
 // Nouveaux styles pour les cartes (inspirés de AdminMaterialTypes.jsx)
 const cardClasses = {
@@ -279,7 +280,7 @@ export default function CategoryItemsPage() {
                                 onClick={() => handleMaterialClick(material.id)}
                             >
                                 <div className={cardClasses.imageContainer}>
-                                    <img
+                                    <ApiImage
                                         src={
                                             material.image ||
                                             "/images/default-material.jpg"

--- a/patrimoine-mtnd/src/pages/admin/MaterialDetailPage.jsx
+++ b/patrimoine-mtnd/src/pages/admin/MaterialDetailPage.jsx
@@ -16,6 +16,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import materialService from "@/services/materialService"
 import AppSidebar from "@/components/app-sidebar"
 import { API_BASE_URL } from "@/config/api"
+import ApiImage from "@/components/ui/ApiImage"
 import {
     Edit,
     FileText,
@@ -279,7 +280,7 @@ export default function MaterialDetailPage() {
                                         {/* Image à gauche */}
                                         {material.image && (
                                             <div className="w-full md:w-1/3 flex justify-center">
-                                                <img
+                                                <ApiImage
                                                     src={`${API_BASE_URL}${material.image}`}
                                                     alt={material.name}
                                                     className="rounded-lg border shadow-sm max-h-96 w-full object-contain"

--- a/patrimoine-mtnd/src/pages/admin/SubCategoriesPage.jsx
+++ b/patrimoine-mtnd/src/pages/admin/SubCategoriesPage.jsx
@@ -4,6 +4,7 @@ import materialService from "@/services/materialService";
 import { ArrowLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { toast } from "react-hot-toast";
+import ApiImage from "@/components/ui/ApiImage";
 
 export default function SubCategoriesPage() {
   const { type } = useParams();
@@ -100,7 +101,7 @@ export default function SubCategoriesPage() {
             onClick={() => navigate(`/admin/${type}/${category.code}`)}
             className="relative rounded-3xl overflow-hidden shadow-lg hover:shadow-2xl transform hover:-translate-y-2 transition-all duration-300 cursor-pointer group"
           >
-            <img
+            <ApiImage
               src={category.image_url || "/placeholder.jpeg"}
               alt={category.name}
               className="w-full h-80 object-cover brightness-110 contrast-110 saturate-125 transition-transform duration-700 group-hover:scale-105"

--- a/patrimoine-mtnd/src/pages/agents/AgentDashboardPage.jsx
+++ b/patrimoine-mtnd/src/pages/agents/AgentDashboardPage.jsx
@@ -7,6 +7,7 @@ import { useAuth } from "@/context/AuthContext"
 import { StatCard } from "@/components/ui/stat-card"
 import { API_BASE_URL } from "@/config/api"
 import { Input } from "@/components/ui/input"
+import ApiImage from "@/components/ui/ApiImage"
 import {
     Search,
     Package,
@@ -187,7 +188,7 @@ export default function AgentDashboardPage() {
                             }
                         >
                             <div className={cardClasses.imageContainer}>
-                                <img
+                                <ApiImage
                                     src={
                                         material.image
                                             ? `${API_BASE_URL}${material.image}`

--- a/patrimoine-mtnd/src/pages/director/DirDashboardPage.jsx
+++ b/patrimoine-mtnd/src/pages/director/DirDashboardPage.jsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { API_BASE_URL } from "@/config/api"
+import ApiImage from "@/components/ui/ApiImage"
 import {
     Search,
     PlusCircle,
@@ -200,7 +201,7 @@ export default function DirDashboardPage() {
                             onClick={() => handleMaterialClick(material.id)}
                         >
                             <div className={cardClasses.imageContainer}>
-                                <img
+                                <ApiImage
                                     src={
                                         material.image
                                             ? `${API_BASE_URL}${material.image}`


### PR DESCRIPTION
## Summary
- swap inline `<img>` tags with `<ApiImage>` where API paths are used
- ensure `ApiImage` is imported in affected components

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6877df3969e083299e2c9e10c8f8c5a4