### PR TITLE
Filtre du compte de commentaires racine

### DIFF
--- a/controllers/post_controller.py
+++ b/controllers/post_controller.py
@@ -38,7 +38,7 @@ class IntranetPostController(http.Controller):
                     for att in post.attachment_ids
                 ],
                 'like_count': len(post.like_ids),
-                'comment_count': len(post.comment_ids),
+                'comment_count': len([c for c in post.comment_ids if not c.parent_id]),
                 'view_count': post.view_count,
             })
         return Response(
@@ -111,7 +111,7 @@ class IntranetPostController(http.Controller):
                 for att in record.attachment_ids
             ],
             'like_count': len(record.like_ids),
-            'comment_count': len(record.comment_ids),
+            'comment_count': len([c for c in record.comment_ids if not c.parent_id]),
         }
 
         return Response(


### PR DESCRIPTION
## Summary
- ne compter que les commentaires racines lors du calcul de `comment_count`
- tester que `list_posts` ignore les commentaires enfants

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877e7492c848329a198541c776e3fe4