### PR TITLE
Fix default API base URL

### DIFF
--- a/patrimoine-mtnd/src/config/api.js
+++ b/patrimoine-mtnd/src/config/api.js
@@ -1,1 +1,6 @@
-export const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost';
+// Resolve the API base URL either from the Vite environment variable
+// or fall back to the current origin. This avoids hardcoding a port
+// when the frontend is served behind a proxy (e.g. Nginx or Vite).
+export const API_BASE_URL =
+  import.meta.env.VITE_API_URL ||
+  (typeof window !== 'undefined' ? window.location.origin : '');

--- a/patrimoine-mtnd/src/env.d.ts
+++ b/patrimoine-mtnd/src/env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_API_URL: string;
+  readonly VITE_API_URL?: string;
   readonly VITE_ODOO_DB: string;
 }
 


### PR DESCRIPTION
## Summary
- fallback to `window.location.origin` for `API_BASE_URL`
- make `VITE_API_URL` optional in env typings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877e73a93ec8329b25402f2a5d75e50