### PR TITLE
Fix admin post link, like color and stats click

### DIFF
--- a/controllers/asset_controller.py
+++ b/controllers/asset_controller.py
@@ -969,14 +969,15 @@ class PatrimoineAssetController(http.Controller):
 
             value_stats = []
             for stat in stats_raw:
-                dept_name = (
-                    stat.get("department_id")[1]
+                dept_id, dept_name = (
+                    stat.get("department_id")
                     if stat.get("department_id")
-                    else "Non défini"
+                    else (None, "Non défini")
                 )
                 total_value = stat.get("valeur_acquisition", 0)
                 value_stats.append(
                     {
+                        "id": dept_id,
                         "name": dept_name,
                         "value": total_value,
                     }

--- a/controllers/post_controller.py
+++ b/controllers/post_controller.py
@@ -23,7 +23,9 @@ class IntranetPostController(http.Controller):
     def list_posts(self, **kwargs):
         posts = request.env['intranet.post'].sudo().search([], order='create_date desc')
         result = []
+        user_id = request.env.user.id
         for post in posts:
+            liked = any(l.user_id.id == user_id for l in post.like_ids)
             result.append({
                 'id': post.id,
                 'title': post.name,
@@ -40,6 +42,7 @@ class IntranetPostController(http.Controller):
                 'like_count': len(post.like_ids),
                 'comment_count': len([c for c in post.comment_ids if not c.parent_id]),
                 'view_count': post.view_count,
+                'liked': liked,
             })
         return Response(
             json.dumps({'status': 'success', 'data': result}, default=str),

--- a/patrimoine-mtnd/src/components/posts/Post.jsx
+++ b/patrimoine-mtnd/src/components/posts/Post.jsx
@@ -24,7 +24,7 @@ export default function Post({ post }) {
     // On suppose que ces données viennent de l'API
     const { currentUser } = useAuth()
     const [likes, setLikes] = useState(post.like_count || 0)
-    const [hasLiked, setHasLiked] = useState(false) // Idéalement, l'API devrait nous dire si l'utilisateur actuel a déjà liké
+    const [hasLiked, setHasLiked] = useState(post.liked || false)
     const [comments, setComments] = useState([])
     const [commentCount, setCommentCount] = useState(post.comment_count || 0)
     const [replyTo, setReplyTo] = useState(null)

--- a/patrimoine-mtnd/src/components/ui/button.tsx
+++ b/patrimoine-mtnd/src/components/ui/button.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { Slot } from "@radix-ui/react-slot"
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
     variant?:
@@ -46,9 +47,10 @@ const Button = React.forwardRef(
             icon: "w-9 h-9",
         }
 
+        const Comp = asChild ? Slot : "button"
         return (
-            <button
-                ref={ref}
+            <Comp
+                ref={ref as any}
                 className={`${baseClasses} ${variantClasses[variant]} ${sizeClasses[size]} ${className}`}
                 {...props}
             />

--- a/patrimoine-mtnd/src/pages/admin/AdminStatsPage.jsx
+++ b/patrimoine-mtnd/src/pages/admin/AdminStatsPage.jsx
@@ -104,6 +104,22 @@ export default function AdminStatsPage() {
         }
     }
 
+    const handleAgeClick = data => {
+        if (data?.activeLabel) {
+            navigate(
+                `/admin/materiels/filtres?age=${encodeURIComponent(data.activeLabel)}`
+            )
+        }
+    }
+
+    const handleDepartmentValueClick = data => {
+        if (data?.activePayload?.[0]?.payload?.id) {
+            navigate(
+                `/admin/materiels/filtres?departmentId=${data.activePayload[0].payload.id}`
+            )
+        }
+    }
+
     if (isLoading) return <div className="p-8 text-center">Chargement...</div>
     if (error)
         return <div className="p-8 text-center text-red-500">{error}</div>
@@ -223,7 +239,11 @@ export default function AdminStatsPage() {
                         style={{ height: "300px" }}
                     >
                         <ResponsiveContainer>
-                            <BarChart data={statsByAge}>
+                            <BarChart
+                                data={statsByAge}
+                                onClick={handleAgeClick}
+                                style={{ cursor: "pointer" }}
+                            >
                                 <XAxis
                                     dataKey="name"
                                     angle={-20}
@@ -254,7 +274,11 @@ export default function AdminStatsPage() {
                         style={{ height: "300px" }}
                     >
                         <ResponsiveContainer>
-                            <BarChart data={statsByDepartmentValue}>
+                            <BarChart
+                                data={statsByDepartmentValue}
+                                onClick={handleDepartmentValueClick}
+                                style={{ cursor: "pointer" }}
+                            >
                                 <XAxis dataKey="name" />
                                 <YAxis tickFormatter={toCfa} width={90} />
                                 <Tooltip formatter={toCfa} />

--- a/tests/test_post_controller.py
+++ b/tests/test_post_controller.py
@@ -155,6 +155,34 @@ class PostControllerTest(unittest.TestCase):
         payload = json.loads(args[0])
         self.assertEqual(payload['data'][0]['comment_count'], 1)
 
+    @patch('controllers.post_controller.Response')
+    @patch('controllers.post_controller.request')
+    def test_list_posts_includes_liked_flag(self, mock_request, mock_response):
+        env = MagicMock()
+        like_user = MagicMock(id=3)
+        post = MagicMock(
+            id=1,
+            name='A',
+            body='b',
+            user_id=MagicMock(name='u', id=2),
+            create_date='2024-01-01',
+            post_type='text',
+            attachment_ids=[],
+            like_ids=[MagicMock(user_id=like_user)],
+            comment_ids=[],
+            view_count=0,
+            image=False,
+        )
+        env['intranet.post'].sudo().search.return_value = [post]
+        mock_request.env = env
+        mock_request.env.user.id = 3
+
+        self.controller.list_posts()
+
+        args, kwargs = mock_response.call_args
+        payload = json.loads(args[0])
+        self.assertTrue(payload['data'][0]['liked'])
+
     @patch('controllers.post_controller.request')
     def test_toggle_like_create(self, mock_request):
         env = MagicMock()


### PR DESCRIPTION
## Summary
- button component supports `asChild` to render links
- include whether current user liked each post
- add department id to value stats
- show liked state in Post component
- make age/value charts navigable
- expand tests for liked flag

## Testing
- `pytest -q`
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68790be978a48329b90c12ca26e8eff0