### PR TITLE
Remove ApiImage component in frontend

### DIFF
--- a/patrimoine-mtnd/src/components/posts/Post.jsx
+++ b/patrimoine-mtnd/src/components/posts/Post.jsx
@@ -3,7 +3,6 @@ import postsService from "../../services/postsService"
 import { ThumbsUp, MessageCircle } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
-import ApiImage from "@/components/ui/ApiImage"
 import { API_BASE_URL } from "@/config/api"
 import { useAuth } from "@/context/AuthContext"
 
@@ -127,7 +126,7 @@ export default function Post({ post }) {
                     {post.body}
                 </p>
                 {post.image && (
-                    <ApiImage
+                    <img
                         src={`${API_BASE_URL}${post.image}`}
                         alt="Image du post"
                         className="w-full rounded-lg border border-slate-200 dark:border-slate-700"

--- a/patrimoine-mtnd/src/components/ui/ApiImage.jsx
+++ b/patrimoine-mtnd/src/components/ui/ApiImage.jsx
@@ -1,9 +1,0 @@
-import React from 'react'
-import { API_BASE_URL } from '@/config/api'
-
-function ApiImage({ src, ...props }) {
-  const resolvedSrc = src && src.startsWith('/') ? `${API_BASE_URL}${src}` : src
-  return <img src={resolvedSrc} {...props} />
-}
-
-export default ApiImage

--- a/patrimoine-mtnd/src/pages/admin/AdminMaterialTypes.jsx
+++ b/patrimoine-mtnd/src/pages/admin/AdminMaterialTypes.jsx
@@ -1,5 +1,4 @@
 import { useNavigate } from "react-router-dom"
-import ApiImage from "@/components/ui/ApiImage"
 
 export default function AdminMaterialTypes() {
     const navigate = useNavigate()
@@ -43,7 +42,7 @@ export default function AdminMaterialTypes() {
                         onClick={() => navigate(type.route)}
                         className="relative rounded-3xl overflow-hidden shadow-lg hover:shadow-2xl transform hover:-translate-y-2 transition-all duration-300 cursor-pointer"
                     >
-                        <ApiImage
+                        <img
                             src={type.image}
                             alt={type.name}
                             className="w-full h-80 object-cover brightness-110 contrast-110 saturate-125 transition-transform duration-700 group-hover:scale-105"

--- a/patrimoine-mtnd/src/pages/admin/CategoryItemsPage.jsx
+++ b/patrimoine-mtnd/src/pages/admin/CategoryItemsPage.jsx
@@ -9,7 +9,6 @@ import { Card, CardContent } from "@/components/ui/card";
 import { toast } from "react-hot-toast"
 import { Search, PlusCircle, Calendar, MapPin, Euro } from "lucide-react";
 import materialService from "@/services/materialService";
-import ApiImage from "@/components/ui/ApiImage";
 import { API_BASE_URL } from "@/config/api";
 
 // Nouveaux styles pour les cartes (inspirés de AdminMaterialTypes.jsx)
@@ -281,7 +280,7 @@ export default function CategoryItemsPage() {
                                 onClick={() => handleMaterialClick(material.id)}
                             >
                                 <div className={cardClasses.imageContainer}>
-                                    <ApiImage
+                                    <img
                                         src={
                                             material.image
                                                 ? `${import.meta.env.VITE_ODOO_URL || "http://localhost:8069"}${material.image}`

--- a/patrimoine-mtnd/src/pages/admin/MaterialDetailPage.jsx
+++ b/patrimoine-mtnd/src/pages/admin/MaterialDetailPage.jsx
@@ -16,7 +16,6 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import materialService from "@/services/materialService"
 import AppSidebar from "@/components/app-sidebar"
 import { API_BASE_URL } from "@/config/api"
-import ApiImage from "@/components/ui/ApiImage"
 import {
     Edit,
     FileText,
@@ -280,7 +279,7 @@ export default function MaterialDetailPage() {
                                         {/* Image à gauche */}
                                         {material.image && (
                                             <div className="w-full md:w-1/3 flex justify-center">
-                                                <ApiImage
+                                                <img
                                                     src={`${API_BASE_URL}${material.image}`}
                                                     alt={material.name}
                                                     className="rounded-lg border shadow-sm max-h-96 w-full object-contain"

--- a/patrimoine-mtnd/src/pages/admin/SubCategoriesPage.jsx
+++ b/patrimoine-mtnd/src/pages/admin/SubCategoriesPage.jsx
@@ -6,8 +6,6 @@ import materialService from "@/services/materialService"
 import { ArrowLeft } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { toast } from "react-hot-toast"
-// On importe uniquement le composant ApiImage
-import ApiImage from "@/components/ui/ApiImage"
 
 export default function SubCategoriesPage() {
     const { type } = useParams()
@@ -102,8 +100,7 @@ export default function SubCategoriesPage() {
                         }
                         className="relative rounded-3xl overflow-hidden shadow-lg hover:shadow-2xl transform hover:-translate-y-2 transition-all duration-300 cursor-pointer group"
                     >
-                        {/* ON UTILISE LE COMPOSANT ApiImage EN LUI PASSANT DIRECTEMENT L'URL RELATIVE */}
-                        <ApiImage
+                        <img
                             src={category.image_url}
                             alt={category.name}
                             className="w-full h-80 object-cover brightness-110 contrast-110 saturate-125 transition-transform duration-700 group-hover:scale-105"

--- a/patrimoine-mtnd/src/pages/agents/AgentDashboardPage.jsx
+++ b/patrimoine-mtnd/src/pages/agents/AgentDashboardPage.jsx
@@ -7,7 +7,6 @@ import { useAuth } from "@/context/AuthContext"
 import { StatCard } from "@/components/ui/stat-card"
 import { API_BASE_URL } from "@/config/api"
 import { Input } from "@/components/ui/input"
-import ApiImage from "@/components/ui/ApiImage"
 import {
     Search,
     Package,
@@ -188,7 +187,7 @@ export default function AgentDashboardPage() {
                             }
                         >
                             <div className={cardClasses.imageContainer}>
-                                <ApiImage
+                                <img
                                     src={
                                         material.image
                                             ? `${API_BASE_URL}${material.image}`

--- a/patrimoine-mtnd/src/pages/director/DirDashboardPage.jsx
+++ b/patrimoine-mtnd/src/pages/director/DirDashboardPage.jsx
@@ -8,7 +8,6 @@ import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { API_BASE_URL } from "@/config/api"
-import ApiImage from "@/components/ui/ApiImage"
 import {
     Search,
     PlusCircle,
@@ -201,7 +200,7 @@ export default function DirDashboardPage() {
                             onClick={() => handleMaterialClick(material.id)}
                         >
                             <div className={cardClasses.imageContainer}>
-                                <ApiImage
+                                <img
                                     src={
                                         material.image
                                             ? `${API_BASE_URL}${material.image}`


### PR DESCRIPTION
## Summary
- remove `ApiImage` component file
- replace `ApiImage` usage with `<img>` tags across pages and posts
- clean up comments referencing `ApiImage`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687924e3a01883298c8064eb97a80aee