### PR TITLE
Update material image handling

### DIFF
--- a/patrimoine-mtnd/src/pages/admin/MaterialDetailPage.jsx
+++ b/patrimoine-mtnd/src/pages/admin/MaterialDetailPage.jsx
@@ -15,8 +15,7 @@ import { Separator } from "@/components/ui/separator"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import materialService from "@/services/materialService"
 import AppSidebar from "@/components/app-sidebar"
-import { API_BASE_URL } from "@/config/api"
-import ApiImage from "@/components/ui/ApiImage"
+
 import {
     Edit,
     FileText,
@@ -278,15 +277,20 @@ export default function MaterialDetailPage() {
                                 <CardContent className="pt-6">
                                     <div className="flex flex-col md:flex-row gap-8">
                                         {/* Image à gauche */}
-                                        {material.image && (
-                                            <div className="w-full md:w-1/3 flex justify-center">
-                                                <ApiImage
-                                                    src={`${API_BASE_URL}${material.image}`}
-                                                    alt={material.name}
-                                                    className="rounded-lg border shadow-sm max-h-96 w-full object-contain"
-                                                />
-                                            </div>
-                                        )}
+                                        <div className="w-full md:w-1/3 flex justify-center">
+                                            <img
+                                                src={
+                                                    material.image
+                                                        ? `${import.meta.env.VITE_ODOO_URL || 'http://localhost:8069'}${material.image}`
+                                                        : '/images/default-material.jpg'
+                                                }
+                                                alt={material.name}
+                                                className="rounded-lg border shadow-sm max-h-96 w-full object-contain"
+                                                onError={e => {
+                                                    e.target.src = '/images/default-material.jpg'
+                                                }}
+                                            />
+                                        </div>
 
                                         {/* Informations à droite */}
                                         <div className="w-full md:w-2/3 grid grid-cols-1 md:grid-cols-2 gap-8">

--- a/patrimoine-mtnd/src/pages/agents/AgentDashboardPage.jsx
+++ b/patrimoine-mtnd/src/pages/agents/AgentDashboardPage.jsx
@@ -5,9 +5,7 @@ import { Card, CardContent } from "@/components/ui/card"
 import materialService from "@/services/materialService"
 import { useAuth } from "@/context/AuthContext"
 import { StatCard } from "@/components/ui/stat-card"
-import { API_BASE_URL } from "@/config/api"
 import { Input } from "@/components/ui/input"
-import ApiImage from "@/components/ui/ApiImage"
 import {
     Search,
     Package,
@@ -188,17 +186,17 @@ export default function AgentDashboardPage() {
                             }
                         >
                             <div className={cardClasses.imageContainer}>
-                                <ApiImage
+                                <img
                                     src={
                                         material.image
-                                            ? `${API_BASE_URL}${material.image}`
-                                            : "/images/default-material.jpg"
+                                            ? `${import.meta.env.VITE_ODOO_URL || 'http://localhost:8069'}${material.image}`
+                                            : '/images/default-material.jpg'
                                     }
                                     alt={material.name}
                                     className={cardClasses.image}
                                     onError={e => {
                                         e.target.src =
-                                            "/images/default-material.jpg"
+                                            '/images/default-material.jpg'
                                     }}
                                 />
                                 <div className={cardClasses.imageOverlay} />

--- a/patrimoine-mtnd/src/pages/director/DirDashboardPage.jsx
+++ b/patrimoine-mtnd/src/pages/director/DirDashboardPage.jsx
@@ -7,8 +7,6 @@ import { StatCard } from "@/components/ui/stat-card"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
-import { API_BASE_URL } from "@/config/api"
-import ApiImage from "@/components/ui/ApiImage"
 import {
     Search,
     PlusCircle,
@@ -201,17 +199,17 @@ export default function DirDashboardPage() {
                             onClick={() => handleMaterialClick(material.id)}
                         >
                             <div className={cardClasses.imageContainer}>
-                                <ApiImage
+                                <img
                                     src={
                                         material.image
-                                            ? `${API_BASE_URL}${material.image}`
-                                            : "/images/default-material.jpg"
+                                            ? `${import.meta.env.VITE_ODOO_URL || 'http://localhost:8069'}${material.image}`
+                                            : '/images/default-material.jpg'
                                     }
                                     alt={material.name}
                                     className={cardClasses.image}
                                     onError={e => {
                                         e.target.src =
-                                            "/images/default-material.jpg"
+                                            '/images/default-material.jpg'
                                     }}
                                 />
                                 <div className={cardClasses.imageOverlay} />


### PR DESCRIPTION
## Summary
- switch material components from `ApiImage` to `img`
- construct image URLs using `VITE_ODOO_URL` with fallback to localhost
- keep default image handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687924e605348329a01a19d78d775871