### PR TITLE
Enable TS to import JS services

### DIFF
--- a/patrimoine-mtnd/tsconfig.json
+++ b/patrimoine-mtnd/tsconfig.json
@@ -16,6 +16,7 @@
         "forceConsistentCasingInFileNames": true,
         "allowSyntheticDefaultImports": true,
         "esModuleInterop": true,
+        "allowJs": true,
 
         "baseUrl": ".",
         "paths": {


### PR DESCRIPTION
## Summary
- enable `allowJs` in the frontend tsconfig so TypeScript resolves JS service files

## Testing
- `pytest -q`
- `npm --prefix patrimoine-mtnd test --silent` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687940d290a883298ac48e8d434af97d