### PR TITLE
Add admin post details route

### DIFF
--- a/patrimoine-mtnd/src/App.jsx
+++ b/patrimoine-mtnd/src/App.jsx
@@ -17,6 +17,7 @@ import AdminDemandeMateriel from './pages/admin/AdminDemandesMateriel';
 import AdminMouvement from './pages/admin/AdminMouvement';
 import AdminDeclarationsPerte from './pages/admin/AdminDeclarationsPerte';
 import AdminPostsPage from './pages/admin/AdminPostsPage';
+import PostDetailPage from './pages/admin/PostDetailPage';
 import AdminStatsPage from './pages/admin/AdminStatsPage';
 import DeclarationPerte from './pages/DeclarationPerte';
 import MyDeclarationsPage from './pages/user/MyDeclarationsPage';
@@ -121,6 +122,14 @@ function AppContent() {
                   element={
                       <ProtectedRoute roles={[ROLES.ADMIN]}>
                           <AdminPostsPage />
+                      </ProtectedRoute>
+                  }
+              />
+              <Route
+                  path="/admin/posts/:id"
+                  element={
+                      <ProtectedRoute roles={[ROLES.ADMIN]}>
+                          <PostDetailPage />
                       </ProtectedRoute>
                   }
               />

--- a/patrimoine-mtnd/src/pages/admin/PostDetailPage.jsx
+++ b/patrimoine-mtnd/src/pages/admin/PostDetailPage.jsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import postsService from "@/services/postsService";
+import Post from "@/components/posts/Post";
+
+export default function PostDetailPage() {
+    const { id } = useParams();
+    const [post, setPost] = useState(null);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        postsService
+            .fetchPosts()
+            .then(data => {
+                const found = Array.isArray(data)
+                    ? data.find(p => String(p.id) === String(id))
+                    : null;
+                setPost(found || null);
+            })
+            .catch(() => {})
+            .finally(() => setLoading(false));
+    }, [id]);
+
+    if (loading) {
+        return <div className="p-8 text-center">Chargement...</div>;
+    }
+
+    if (!post) {
+        return <div className="p-8 text-center">Post introuvable.</div>;
+    }
+
+    return (
+        <div className="w-full max-w-2xl mx-auto py-8">
+            <Post post={post} />
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- create `PostDetailPage` component for viewing a single post
- expose PostDetailPage on `/admin/posts/:id` route

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879978547c883298062f865a13ccc7c