### PR TITLE
Add error state to PostsPage

### DIFF
--- a/patrimoine-mtnd/src/pages/posts/PostsPage.jsx
+++ b/patrimoine-mtnd/src/pages/posts/PostsPage.jsx
@@ -3,18 +3,22 @@ import postsService from "../../services/postsService"
 import CreatePost from "../../components/posts/CreatePost"
 import PostsList from "../../components/posts/PostsList"
 import { Button } from "@/components/ui/button"
+import { toast } from "react-hot-toast"
 
 export default function PostsPage() {
     const [posts, setPosts] = useState([])
     const [isLoading, setIsLoading] = useState(true)
     const [showCreate, setShowCreate] = useState(false)
+    const [error, setError] = useState(null)
 
     const fetchAndSetPosts = useCallback(async () => {
         try {
             const fetchedPosts = await postsService.fetchPosts()
             setPosts(Array.isArray(fetchedPosts) ? fetchedPosts : [])
-        } catch (error) {
-            console.error("Failed to fetch posts", error)
+        } catch (err) {
+            console.error("Failed to fetch posts", err)
+            setError("Erreur lors du chargement des posts.")
+            toast.error("Impossible de récupérer les posts")
         } finally {
             setIsLoading(false)
         }
@@ -35,6 +39,9 @@ export default function PostsPage() {
             <h1 className="text-3xl font-bold mb-6 text-white">
                 Fil d'Actualités
             </h1>
+            {error && (
+                <p className="text-red-500 text-center mb-4">{error}</p>
+            )}
             {showCreate ? (
                 <CreatePost onCreated={handlePostCreated} />
             ) : (


### PR DESCRIPTION
## Summary
- add toast import and error state
- show toast and store error when fetch fails
- display error message on Posts page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879fff7e46083298fcbb32459316154