### PR TITLE
Implement pagination for posts feed

### DIFF
--- a/patrimoine-mtnd/src/pages/posts/PostsPage.jsx
+++ b/patrimoine-mtnd/src/pages/posts/PostsPage.jsx
@@ -3,22 +3,30 @@ import postsService from "../../services/postsService"
 import CreatePost from "../../components/posts/CreatePost"
 import PostsList from "../../components/posts/PostsList"
 import { Button } from "@/components/ui/button"
+import {
+    Pagination,
+    PaginationContent,
+    PaginationItem,
+    PaginationLink,
+} from "@/components/ui/pagination"
 
 export default function PostsPage() {
     const [posts, setPosts] = useState([])
     const [isLoading, setIsLoading] = useState(true)
     const [showCreate, setShowCreate] = useState(false)
+    const [page, setPage] = useState(1)
+    const PAGE_SIZE = 10
 
     const fetchAndSetPosts = useCallback(async () => {
         try {
-            const fetchedPosts = await postsService.fetchPosts()
+            const fetchedPosts = await postsService.fetchPosts(page, PAGE_SIZE)
             setPosts(Array.isArray(fetchedPosts) ? fetchedPosts : [])
         } catch (error) {
             console.error("Failed to fetch posts", error)
         } finally {
             setIsLoading(false)
         }
-    }, [])
+    }, [page])
 
     useEffect(() => {
         fetchAndSetPosts()
@@ -49,6 +57,29 @@ export default function PostsPage() {
             ) : (
                 <PostsList posts={posts} />
             )}
+            <Pagination className="mt-4">
+                <PaginationContent>
+                    <PaginationItem>
+                        <PaginationLink
+                            href="#"
+                            size="default"
+                            onClick={() => setPage(p => Math.max(1, p - 1))}
+                            className={page === 1 ? "pointer-events-none opacity-50" : ""}
+                        >
+                            Précédent
+                        </PaginationLink>
+                    </PaginationItem>
+                    <PaginationItem>
+                        <PaginationLink
+                            href="#"
+                            size="default"
+                            onClick={() => setPage(p => p + 1)}
+                        >
+                            Suivant
+                        </PaginationLink>
+                    </PaginationItem>
+                </PaginationContent>
+            </Pagination>
         </div>
     )
 }

--- a/patrimoine-mtnd/src/services/postsService.js
+++ b/patrimoine-mtnd/src/services/postsService.js
@@ -1,7 +1,14 @@
 import api from './apiConfig'
 
-const fetchPosts = () =>
-  api.get('/api/intranet/posts').then(res => res.data.data)
+const fetchPosts = (page, pageSize) => {
+  const params = {}
+  if (page !== undefined) params.page = page
+  if (pageSize !== undefined) params.page_size = pageSize
+  const options = Object.keys(params).length ? { params } : undefined
+  return api
+    .get('/api/intranet/posts', options)
+    .then(res => res.data.data)
+}
 
 const fetchPostById = async (id) => {
   const allPosts = await fetchPosts()

--- a/patrimoine-mtnd/src/tests/integration/postsService.test.js
+++ b/patrimoine-mtnd/src/tests/integration/postsService.test.js
@@ -23,6 +23,17 @@ describe('postsService', () => {
     expect(posts).toEqual([{ id: 1 }])
   })
 
+  test('fetchPosts forwards pagination params', async () => {
+    api.get.mockResolvedValue({ data: { status: 'success', data: [] } })
+
+    await postsService.fetchPosts(2, 5)
+
+    expect(api.get).toHaveBeenCalledWith(
+      '/api/intranet/posts',
+      { params: { page: 2, page_size: 5 } }
+    )
+  })
+
   test('createPost sends form data', async () => {
     const fd = new FormData()
     api.post.mockResolvedValue({ data: { status: 'success', data: { id: 2 } } })


### PR DESCRIPTION
## Summary
- extend `fetchPosts` so it forwards optional pagination parameters
- allow `PostsPage` to track page and request the current page
- provide basic Prev/Next buttons
- test that pagination parameters are forwarded

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a0001e4c48329a9e82bfa86154c12