### PR TITLE
Implement react-query for posts

### DIFF
--- a/patrimoine-mtnd/src/main.jsx
+++ b/patrimoine-mtnd/src/main.jsx
@@ -1,10 +1,15 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './App';
-import './index.css';
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import App from './App'
+import './index.css'
+
+const queryClient = new QueryClient()
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </React.StrictMode>
 );

--- a/patrimoine-mtnd/src/pages/posts/PostsPage.jsx
+++ b/patrimoine-mtnd/src/pages/posts/PostsPage.jsx
@@ -1,32 +1,19 @@
-import React, { useEffect, useState, useCallback } from "react"
+import React, { useState } from "react"
+import { useQuery } from "@tanstack/react-query"
 import postsService from "../../services/postsService"
 import CreatePost from "../../components/posts/CreatePost"
 import PostsList from "../../components/posts/PostsList"
 import { Button } from "@/components/ui/button"
 
 export default function PostsPage() {
-    const [posts, setPosts] = useState([])
-    const [isLoading, setIsLoading] = useState(true)
     const [showCreate, setShowCreate] = useState(false)
 
-    const fetchAndSetPosts = useCallback(async () => {
-        try {
-            const fetchedPosts = await postsService.fetchPosts()
-            setPosts(Array.isArray(fetchedPosts) ? fetchedPosts : [])
-        } catch (error) {
-            console.error("Failed to fetch posts", error)
-        } finally {
-            setIsLoading(false)
-        }
-    }, [])
-
-    useEffect(() => {
-        fetchAndSetPosts()
-    }, [fetchAndSetPosts])
+    const {
+        data: posts = [],
+        isLoading,
+    } = useQuery(["posts"], postsService.fetchPosts)
 
     const handlePostCreated = () => {
-        // Simplement rafraîchir toute la liste pour voir le nouveau post en haut
-        fetchAndSetPosts()
         setShowCreate(false)
     }
 


### PR DESCRIPTION
## Summary
- add QueryClientProvider at app root
- load posts via `useQuery`
- create posts with `useMutation`
- update integration tests for new logic

## Testing
- `pytest -q`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a0005f2b483299d3b4f5b2d3660b3