### PR TITLE
Add posts page enhancements and tests

### DIFF
--- a/patrimoine-mtnd/src/pages/posts/PostsPage.jsx
+++ b/patrimoine-mtnd/src/pages/posts/PostsPage.jsx
@@ -3,18 +3,28 @@ import postsService from "../../services/postsService"
 import CreatePost from "../../components/posts/CreatePost"
 import PostsList from "../../components/posts/PostsList"
 import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { toast } from "react-hot-toast"
+import { useAuth } from "@/context/AuthContext"
 
 export default function PostsPage() {
+    const { currentUser } = useAuth()
     const [posts, setPosts] = useState([])
     const [isLoading, setIsLoading] = useState(true)
     const [showCreate, setShowCreate] = useState(false)
+    const [search, setSearch] = useState("")
+    const [error, setError] = useState(null)
 
     const fetchAndSetPosts = useCallback(async () => {
+        setIsLoading(true)
+        setError(null)
         try {
             const fetchedPosts = await postsService.fetchPosts()
             setPosts(Array.isArray(fetchedPosts) ? fetchedPosts : [])
         } catch (error) {
             console.error("Failed to fetch posts", error)
+            setError("Erreur de chargement des posts")
+            toast.error("Erreur lors du chargement des posts.")
         } finally {
             setIsLoading(false)
         }
@@ -30,24 +40,45 @@ export default function PostsPage() {
         setShowCreate(false)
     }
 
+    const filteredPosts = posts.filter(p =>
+        p.title?.toLowerCase().includes(search.toLowerCase()) ||
+        p.body?.toLowerCase().includes(search.toLowerCase())
+    )
+
+    const canPost = currentUser && currentUser.role !== 'user'
+
     return (
         <div className="w-full max-w-2xl mx-auto py-8">
             <h1 className="text-3xl font-bold mb-6 text-white">
                 Fil d'Actualités
             </h1>
+            <div className="flex items-center gap-2 mb-4">
+                <Input
+                    placeholder="Rechercher..."
+                    value={search}
+                    onChange={e => setSearch(e.target.value)}
+                />
+                <Button variant="outline" onClick={fetchAndSetPosts}>
+                    Rafraîchir
+                </Button>
+            </div>
             {showCreate ? (
                 <CreatePost onCreated={handlePostCreated} />
             ) : (
-                <Button className="mb-4" onClick={() => setShowCreate(true)}>
-                    Faire un post
-                </Button>
+                canPost && (
+                    <Button className="mb-4" onClick={() => setShowCreate(true)}>
+                        Faire un post
+                    </Button>
+                )
             )}
             {isLoading ? (
-                <p className="text-center text-slate-400">
-                    Chargement des posts...
-                </p>
+                <p className="text-center text-slate-400">Chargement des posts...</p>
+            ) : error ? (
+                <p className="text-center text-red-500">{error}</p>
+            ) : filteredPosts.length > 0 ? (
+                <PostsList posts={filteredPosts} />
             ) : (
-                <PostsList posts={posts} />
+                <p className="text-center text-slate-400">Aucun post trouvé.</p>
             )}
         </div>
     )

--- a/patrimoine-mtnd/src/tests/integration/postsPage.test.jsx
+++ b/patrimoine-mtnd/src/tests/integration/postsPage.test.jsx
@@ -4,6 +4,11 @@ import ReactDOM from 'react-dom/client'
 import postsService from '../../services/postsService'
 import PostsPage from '../../pages/posts/PostsPage'
 
+jest.mock('../../context/AuthContext', () => ({
+  __esModule: true,
+  useAuth: jest.fn(() => ({ currentUser: { role: 'admin_patrimoine' }, loading: false }))
+}))
+
 jest.mock('../../services/postsService', () => ({
   __esModule: true,
   default: {
@@ -69,5 +74,93 @@ describe('PostsPage behaviour', () => {
 
     const firstTitle = container.querySelector('h3').textContent
     expect(firstTitle).toBe('new')
+  })
+
+  test('shows error message on fetch failure', async () => {
+    postsService.fetchPosts.mockRejectedValue(new Error('fail'))
+
+    await act(async () => {
+      ReactDOM.createRoot(container).render(<PostsPage />)
+    })
+    await act(() => Promise.resolve())
+
+    expect(container.textContent).toContain('Erreur')
+  })
+
+  test('displays empty state', async () => {
+    postsService.fetchPosts.mockResolvedValue([])
+
+    await act(async () => {
+      ReactDOM.createRoot(container).render(<PostsPage />)
+    })
+    await act(() => Promise.resolve())
+
+    expect(container.textContent).toContain('Aucun post')
+  })
+
+  test('filters posts using search input', async () => {
+    postsService.fetchPosts.mockResolvedValue([
+      { id: 1, title: 'hello', body: 'b' },
+      { id: 2, title: 'world', body: 'b' }
+    ])
+
+    await act(async () => {
+      ReactDOM.createRoot(container).render(<PostsPage />)
+    })
+    await act(() => Promise.resolve())
+
+    const searchInput = container.querySelector('input[placeholder="Rechercher..."]')
+
+    await act(async () => {
+      searchInput.value = 'world'
+      searchInput.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    await act(() => Promise.resolve())
+
+    expect(container.textContent).toContain('world')
+    expect(container.textContent).not.toContain('hello')
+  })
+
+  test('refresh button reloads posts', async () => {
+    postsService.fetchPosts.mockResolvedValueOnce([{ id: 1, title: 'old', body: 'b' }])
+    postsService.fetchPosts.mockResolvedValueOnce([{ id: 2, title: 'new', body: 'b' }])
+
+    await act(async () => {
+      ReactDOM.createRoot(container).render(<PostsPage />)
+    })
+    await act(() => Promise.resolve())
+
+    expect(container.textContent).toContain('old')
+
+    const refreshBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent.includes('Rafraîchir'))
+    await act(async () => {
+      refreshBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await act(() => Promise.resolve())
+
+    expect(container.textContent).toContain('new')
+  })
+
+  test('Faire un post button visible only for allowed roles', async () => {
+    const { useAuth } = require('../../context/AuthContext')
+    useAuth.mockReturnValueOnce({ currentUser: { role: 'user' }, loading: false })
+    postsService.fetchPosts.mockResolvedValue([])
+
+    await act(async () => {
+      ReactDOM.createRoot(container).render(<PostsPage />)
+    })
+    await act(() => Promise.resolve())
+
+    const createBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent.includes('Faire un post'))
+    expect(createBtn).toBeUndefined()
+
+    useAuth.mockReturnValueOnce({ currentUser: { role: 'admin_patrimoine' }, loading: false })
+    await act(async () => {
+      ReactDOM.createRoot(container).render(<PostsPage />)
+    })
+    await act(() => Promise.resolve())
+
+    const createBtn2 = Array.from(container.querySelectorAll('button')).find(b => b.textContent.includes('Faire un post'))
+    expect(createBtn2).toBeDefined()
   })
 })


### PR DESCRIPTION
## Summary
- improve PostsPage with search, refresh and error handling
- show "Faire un post" only for privileged users
- update integration tests for PostsPage to cover errors, empty state, filtering, refresh and role visibility

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a0006b03083298576c9d7e9ae1285