### PR TITLE
Refactor Response helper

### DIFF
--- a/controllers/asset_controller.py
+++ b/controllers/asset_controller.py
@@ -1,20 +1,14 @@
 from odoo import http, _
 from odoo.fields import Date
 from dateutil.relativedelta import relativedelta
-from odoo.http import request, Response as OdooResponse
+from odoo.http import request
 from odoo.exceptions import AccessError, ValidationError
 import json
 from odoo.osv import expression
 from werkzeug.exceptions import BadRequest
 import base64  # Pour encoder/décoder les fichiers
 import logging
-from .common import handle_api_errors, json_response, CORS_HEADERS
-
-
-def Response(*args, **kwargs):
-    headers = kwargs.pop("headers", {})
-    headers = {**CORS_HEADERS, **headers}
-    return OdooResponse(*args, headers=headers, **kwargs)
+from .common import Response, handle_api_errors, json_response, CORS_HEADERS
 
 _logger = logging.getLogger(__name__)
 

--- a/controllers/chat_controller.py
+++ b/controllers/chat_controller.py
@@ -1,12 +1,6 @@
 from odoo import http
-from odoo.http import request, Response as OdooResponse
-from .common import json_response, CORS_HEADERS
-
-
-def Response(*args, **kwargs):
-    headers = kwargs.pop("headers", {})
-    headers = {**CORS_HEADERS, **headers}
-    return OdooResponse(*args, headers=headers, **kwargs)
+from odoo.http import request
+from .common import Response, json_response, CORS_HEADERS
 import json
 import logging
 _logger = logging.getLogger(__name__)

--- a/controllers/common.py
+++ b/controllers/common.py
@@ -3,7 +3,7 @@ import logging
 import os
 from functools import wraps
 from odoo.exceptions import AccessError, ValidationError
-from odoo.http import Response
+from odoo.http import Response as OdooResponse
 
 # Allow overriding the CORS origin via an environment variable so deployments
 # can specify their frontend URL.  Using a specific origin is required when the
@@ -13,6 +13,13 @@ ALLOWED_ORIGIN = os.environ.get("ALLOWED_ORIGIN", "http://localhost:5174")
 CORS_HEADERS = {
     "Content-Type": "application/json",
 }
+
+
+def Response(*args, **kwargs):
+    """Return an Odoo HTTP Response with default CORS headers."""
+    headers = kwargs.pop("headers", {})
+    headers = {**CORS_HEADERS, **headers}
+    return OdooResponse(*args, headers=headers, **kwargs)
 
 
 def json_response(data, status=200):

--- a/controllers/post_controller.py
+++ b/controllers/post_controller.py
@@ -2,16 +2,10 @@ import json
 import base64
 import logging
 from odoo import http
-from odoo.http import request, Response as OdooResponse
+from odoo.http import request
 from odoo.exceptions import ValidationError
 
-from .common import handle_api_errors, CORS_HEADERS, json_response
-
-
-def Response(*args, **kwargs):
-    headers = kwargs.pop("headers", {})
-    headers = {**CORS_HEADERS, **headers}
-    return OdooResponse(*args, headers=headers, **kwargs)
+from .common import Response, handle_api_errors, CORS_HEADERS, json_response
 
 _logger = logging.getLogger(__name__)
 

--- a/controllers/userApi_controller.py
+++ b/controllers/userApi_controller.py
@@ -1,14 +1,8 @@
 from odoo import http
-from odoo.http import request, Response as OdooResponse
+from odoo.http import request
 import json
 import logging
-from .common import CORS_HEADERS
-
-
-def Response(*args, **kwargs):
-    headers = kwargs.pop("headers", {})
-    headers = {**CORS_HEADERS, **headers}
-    return OdooResponse(*args, headers=headers, **kwargs)
+from .common import Response, CORS_HEADERS
 
 _logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- centralize Response helper in `controllers/common.py`
- import Response from `common` in other controllers

## Testing
- `pytest -q` *(fails: PostControllerTest failing)*

------
https://chatgpt.com/codex/tasks/task_e_687a17e975988329ad762532a9b2fc86