### PR TITLE
Improve pytest compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,3 +161,10 @@ variable `ALLOWED_ORIGIN` on the Odoo server to the URL of your frontend
 appropriate CORS headers based on this value so browsers allow requests that
 include credentials.
 
+## Running the tests
+
+The unit tests can be executed with `pytest`. They rely on small stub
+implementations of the `odoo` package, which are inserted into
+`sys.modules` before the controllers and models are imported. This allows
+the models to be loaded normally even outside an Odoo server.
+

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,16 +1,20 @@
-import sys
+"""Expose all model modules when the package is imported.
 
-if 'pytest' not in sys.modules:
-    from . import asset
-    from . import asset_informatique
-    from . import asset_mobilier
-    from . import asset_vehicule
-    from . import entretien
-    from . import mouvement
-    from . import fiche_vie
-    from . import demande_materiel
-    from . import demande_materiel_ligne
-    from . import pertes
-    from . import chat
-    from . import post
-    from . import chat_test
+The unit tests insert stub implementations of the ``odoo`` package in
+``sys.modules`` before importing this package so the imports below work
+even outside an actual Odoo environment.
+"""
+
+from . import asset
+from . import asset_informatique
+from . import asset_mobilier
+from . import asset_vehicule
+from . import entretien
+from . import mouvement
+from . import fiche_vie
+from . import demande_materiel
+from . import demande_materiel_ligne
+from . import pertes
+from . import chat
+from . import post
+from . import chat_test

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py


### PR DESCRIPTION
## Summary
- always import model modules
- document how to run tests
- configure pytest to ignore non-test modules

## Testing
- `pytest -q` *(fails: 4 failed, 22 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687a17ee36748329b68c7493ff9d0238