### PR TITLE
Add close button for new post form

### DIFF
--- a/patrimoine-mtnd/src/components/posts/CreatePost.jsx
+++ b/patrimoine-mtnd/src/components/posts/CreatePost.jsx
@@ -5,9 +5,9 @@ import { toast } from "react-hot-toast"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
 import { Input } from "@/components/ui/input" // On importe le composant Input
-import { Image } from "lucide-react"
+import { Image, X } from "lucide-react"
 
-export default function CreatePost({ onCreated }) {
+export default function CreatePost({ onCreated, onClose }) {
     // On garde les états séparés pour le titre et le texte
     const [title, setTitle] = useState("")
     const [text, setText] = useState("")
@@ -68,7 +68,16 @@ export default function CreatePost({ onCreated }) {
     }
 
     return (
-        <div className="bg-white dark:bg-slate-800 p-4 rounded-lg shadow-md mb-8">
+        <div className="bg-white dark:bg-slate-800 p-4 rounded-lg shadow-md mb-8 relative">
+            {onClose && (
+                <button
+                    type="button"
+                    onClick={onClose}
+                    className="absolute top-2 right-2 text-slate-500 hover:text-slate-700"
+                >
+                    <X size={18} />
+                </button>
+            )}
             <form onSubmit={handleSubmit}>
                 {/* Champ pour le titre */}
                 <Input

--- a/patrimoine-mtnd/src/pages/posts/PostsPage.jsx
+++ b/patrimoine-mtnd/src/pages/posts/PostsPage.jsx
@@ -84,7 +84,10 @@ export default function PostsPage() {
                 className="mb-4"
             />
             {showCreate ? (
-                <CreatePost onCreated={handlePostCreated} />
+                <CreatePost
+                    onCreated={handlePostCreated}
+                    onClose={() => setShowCreate(false)}
+                />
             ) : (
                 canPost && (
                     <Button className="mb-4" onClick={() => setShowCreate(true)}>


### PR DESCRIPTION
## Summary
- add new optional `onClose` prop to `CreatePost`
- show a close icon to hide the post form
- allow closing the form from `PostsPage`

## Testing
- `pytest -q` *(fails: PostControllerTest::test_add_comment_form_payload et al.)*

------
https://chatgpt.com/codex/tasks/task_e_687a2b872484832982c52729e5d61e59