### PR TITLE
Allow generic file upload for posts

### DIFF
--- a/controllers/post_controller.py
+++ b/controllers/post_controller.py
@@ -55,7 +55,7 @@ class IntranetPostController(http.Controller):
         files = request.httprequest.files
 
         _logger.info(f"Données de formulaire reçues : {post_data}")
-        _logger.info(f"Fichiers reçus : {files.getlist('image')}")
+        _logger.info(f"Fichiers reçus : {files.getlist('file')}")
 
         title = post_data.get("name")
         if not title:
@@ -77,11 +77,11 @@ class IntranetPostController(http.Controller):
             "user_id": request.env.user.id,
         }
 
-        # Gestion de l'image
-        image_file = files.get("image")
-        if image_file:
-            _logger.info("Image détectée, traitement en cours...")
-            vals["image"] = base64.b64encode(image_file.read())
+        # Gestion du fichier
+        upload_file = files.get("file")
+        if upload_file:
+            _logger.info("Fichier détecté, traitement en cours...")
+            vals["image"] = base64.b64encode(upload_file.read())
 
         _logger.info(
             f"Création du post avec les valeurs pour les champs : {list(vals.keys())}"
@@ -120,9 +120,26 @@ class IntranetPostController(http.Controller):
     @http.route('/api/intranet/posts/<int:post_id>/comments', auth='user', type='http', methods=['POST'], csrf=False)
     @handle_api_errors
     def add_comment(self, post_id, **kw):
-        # 1. On lit les données JSON envoyées par le client React (axios)
+        # 1. On lit les données envoyées par le client React
         try:
-            data = json.loads(request.httprequest.data)
+            if request.jsonrequest:
+                data = request.jsonrequest
+            elif kw:
+                data = kw
+            elif getattr(request, 'httprequest', None) and getattr(request.httprequest, 'form', None):
+                try:
+                    data = request.httprequest.form.to_dict()
+                except Exception:
+                    data = {}
+            elif getattr(request, 'httprequest', None) and getattr(request.httprequest, 'data', None):
+                try:
+                    data = json.loads(request.httprequest.data)
+                except Exception:
+                    data = {}
+            else:
+                data = {}
+            if not isinstance(data, dict):
+                data = {}
             content = data.get('content')
             parent_id = data.get('parent_id')
         except Exception as e:

--- a/patrimoine-mtnd/src/components/posts/CreatePost.jsx
+++ b/patrimoine-mtnd/src/components/posts/CreatePost.jsx
@@ -5,14 +5,14 @@ import { toast } from "react-hot-toast"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
 import { Input } from "@/components/ui/input" // On importe le composant Input
-import { Image } from "lucide-react"
+import { File } from "lucide-react"
 
 export default function CreatePost({ onCreated }) {
     // On garde les états séparés pour le titre et le texte
     const [title, setTitle] = useState("")
     const [text, setText] = useState("")
-    const [imageFile, setImageFile] = useState(null)
-    const [imagePreview, setImagePreview] = useState(null)
+    const [file, setFile] = useState(null)
+    const [filePreview, setFilePreview] = useState(null)
 
     const queryClient = useQueryClient()
     const { mutateAsync, isPending } = useMutation({
@@ -28,30 +28,30 @@ export default function CreatePost({ onCreated }) {
     })
 
     const handleFileChange = e => {
-        const file = e.target.files[0]
-        if (file) {
-            setImageFile(file)
-            setImagePreview(URL.createObjectURL(file))
+        const selected = e.target.files[0]
+        if (selected) {
+            setFile(selected)
+            setFilePreview(URL.createObjectURL(selected))
         }
     }
 
     const handleSubmit = async e => {
         e.preventDefault()
-        // On vérifie que le titre et le contenu (texte ou image) sont présents
+        // On vérifie que le titre et le contenu (texte ou fichier) sont présents
         if (!title.trim()) {
             toast.error("Veuillez renseigner un titre pour votre publication.")
             return
         }
-        if (!text.trim() && !imageFile) {
-            toast.error("Veuillez ajouter un contenu ou une image.")
+        if (!text.trim() && !file) {
+            toast.error("Veuillez ajouter un contenu ou un fichier.")
             return
         }
 
         const formData = new FormData()
         formData.append("name", title) // Utilise le champ 'name' attendu par le backend
         formData.append("body", text)
-        if (imageFile) {
-            formData.append("image", imageFile)
+        if (file) {
+            formData.append("file", file)
         }
 
         try {
@@ -59,8 +59,8 @@ export default function CreatePost({ onCreated }) {
             // On réinitialise le formulaire
             setTitle("")
             setText("")
-            setImageFile(null)
-            setImagePreview(null)
+            setFile(null)
+            setFilePreview(null)
             e.target.reset() // Pour vider l'input de type file
         } catch (err) {
             console.error(err)
@@ -86,18 +86,18 @@ export default function CreatePost({ onCreated }) {
                     placeholder="Partagez quelque chose avec l'équipe..."
                     rows="3"
                 />
-                {imagePreview && (
+                {filePreview && (
                     <div className="mt-4 relative w-fit">
                         <img
-                            src={imagePreview}
+                            src={filePreview}
                             alt="Aperçu"
                             className="rounded-lg max-h-40"
                         />
                         <button
                             type="button"
                             onClick={() => {
-                                setImageFile(null)
-                                setImagePreview(null)
+                                setFile(null)
+                                setFilePreview(null)
                             }}
                             className="absolute top-2 right-2 bg-black/50 text-white rounded-full h-6 w-6 flex items-center justify-center"
                         >
@@ -107,16 +107,16 @@ export default function CreatePost({ onCreated }) {
                 )}
                 <div className="flex justify-between items-center mt-4 pt-4 border-t border-slate-200 dark:border-slate-700">
                     <label
-                        htmlFor="image-upload"
+                        htmlFor="file-upload"
                         className="flex items-center gap-2 text-slate-500 hover:text-blue-500 cursor-pointer"
                     >
-                        <Image size={20} />
-                        <span>Photo</span>
+                        <File size={20} />
+                        <span>Fichier</span>
                     </label>
                     <input
-                        id="image-upload"
+                        id="file-upload"
                         type="file"
-                        accept="image/*"
+                        accept="image/*,video/*"
                         className="hidden"
                         onChange={handleFileChange}
                     />


### PR DESCRIPTION
## Summary
- support generic file upload in `CreatePost`
- adjust `post_controller` to accept `file` field
- make `add_comment` robust to different payload formats

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a2f677ea8832998e63a294aacc38a