### PR TITLE
Add post notifications and unread count

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ curl -X POST \
   http://localhost:8069/api/intranet/posts/1/comments?db=<DB>
 ```
 
+### `/api/intranet/posts/unread_count`
+* **GET** : renvoie le nombre de publications non lues par l'utilisateur connecté.
+
 
 ## Troubleshooting
 

--- a/patrimoine-mtnd/src/App.jsx
+++ b/patrimoine-mtnd/src/App.jsx
@@ -3,6 +3,7 @@ import ProtectedRoute from './components/ProtectedRoute';
 import AppLayout from './components/AppLayout';
 import LoginPage from './pages/auth/LoginPage';
 import { AuthProvider, useAuth } from './context/AuthContext';
+import { PostNotificationProvider } from './context/PostNotificationContext';
 
 // Importez vos pages...
 import AdminMaterialTypes from './pages/admin/AdminMaterialTypes';
@@ -313,7 +314,9 @@ function App() {
   return (
     <Router>
       <AuthProvider>
-        <AppContent />
+        <PostNotificationProvider>
+          <AppContent />
+        </PostNotificationProvider>
       </AuthProvider>
     </Router>
   );

--- a/patrimoine-mtnd/src/components/app-sidebar.tsx
+++ b/patrimoine-mtnd/src/components/app-sidebar.tsx
@@ -15,6 +15,8 @@ import React from "react"
 import { useLocation, useNavigate } from "react-router-dom"
 import { useAuth, type User } from "../context/AuthContext"
 import { Button } from "./ui/button"
+import { Badge } from "./ui/badge"
+import { usePostNotifications } from "../context/PostNotificationContext"
 
 interface AppSidebarProps {
     onCollapseChange?: (collapsed: boolean) => void
@@ -26,6 +28,7 @@ export default function AppSidebar({ onCollapseChange }: AppSidebarProps) {
     const [collapsed, setCollapsed] = React.useState(false)
 
     const { currentUser, logout } = useAuth()
+    const { count, setCount } = usePostNotifications()
 
     if (!currentUser) {
         console.error('No current user - redirecting to login')
@@ -203,14 +206,22 @@ export default function AppSidebar({ onCollapseChange }: AppSidebarProps) {
                             ? "bg-slate-700 text-white"
                             : "text-slate-400 hover:bg-slate-700/50 hover:text-white"
                     }`}
-                                    onClick={() => navigate(item.path)}
+                                    onClick={() => {
+                                        if (item.path === '/posts') {
+                                            setCount(0)
+                                        }
+                                        navigate(item.path)
+                                    }}
                                 >
                                     <div className="flex-shrink-0">
                                         {item.icon}
                                     </div>
                                     {!collapsed && (
-                                        <span className="flex-grow text-left">
-                                            {item.label}
+                                        <span className="flex-grow text-left flex items-center justify-between">
+                                            <span>{item.label}</span>
+                                            {item.path === '/posts' && count > 0 && (
+                                                <Badge variant="secondary" className="ml-2">{count}</Badge>
+                                            )}
                                         </span>
                                     )}
                                 </Button>

--- a/patrimoine-mtnd/src/context/PostNotificationContext.jsx
+++ b/patrimoine-mtnd/src/context/PostNotificationContext.jsx
@@ -1,0 +1,29 @@
+import React, { createContext, useContext, useEffect, useState } from 'react'
+import useOdooBus from '@/hooks/useOdooBus'
+import postsService from '@/services/postsService'
+
+const Context = createContext({ count: 0, setCount: () => {} })
+
+export function PostNotificationProvider({ children }) {
+  const [count, setCount] = useState(0)
+
+  useEffect(() => {
+    postsService.fetchUnreadCount().then(setCount).catch(() => {})
+  }, [])
+
+  useOdooBus(notification => {
+    if (notification.type === 'new_post') {
+      setCount(c => c + 1)
+    }
+  })
+
+  return (
+    <Context.Provider value={{ count, setCount }}>
+      {children}
+    </Context.Provider>
+  )
+}
+
+export function usePostNotifications() {
+  return useContext(Context)
+}

--- a/patrimoine-mtnd/src/pages/posts/PostsPage.jsx
+++ b/patrimoine-mtnd/src/pages/posts/PostsPage.jsx
@@ -13,9 +13,11 @@ import {
 import { Spinner } from "@/components/ui/spinner"
 import { toast } from "react-hot-toast"
 import { useAuth } from "@/context/AuthContext"
+import { usePostNotifications } from "@/context/PostNotificationContext"
 
 export default function PostsPage() {
     const { currentUser } = useAuth()
+    const { setCount } = usePostNotifications()
     const canCreate = ["admin_patrimoine", "admin", "agent"].includes(
         currentUser?.role
     )
@@ -43,7 +45,7 @@ export default function PostsPage() {
     }, [page])
 
     useEffect(() => {
-        fetchAndSetPosts()
+        fetchAndSetPosts().then(() => setCount(0))
     }, [fetchAndSetPosts])
 
     const handlePostCreated = () => {

--- a/patrimoine-mtnd/src/services/postsService.js
+++ b/patrimoine-mtnd/src/services/postsService.js
@@ -33,6 +33,9 @@ const likePost = id =>
 const viewPost = id =>
   api.post(`/api/intranet/posts/${id}/views`).then(res => res.data)
 
+const fetchUnreadCount = () =>
+  api.get('/api/intranet/posts/unread_count').then(res => res.data.data.count)
+
 const addComment = (id, content, parentId = null) => {
   console.debug('addComment payload', { id, content, parent_id: parentId })
   return api
@@ -54,5 +57,6 @@ export default {
   addComment,
   viewPost,
   fetchComments,
-  deletePost
+  deletePost,
+  fetchUnreadCount
 }

--- a/patrimoine-mtnd/src/tests/integration/postsService.test.js
+++ b/patrimoine-mtnd/src/tests/integration/postsService.test.js
@@ -90,4 +90,13 @@ describe('postsService', () => {
 
     expect(api.get).toHaveBeenCalledWith('/admin/posts/12/delete')
   })
+
+  test('fetchUnreadCount returns number', async () => {
+    api.get.mockResolvedValue({ data: { status: 'success', data: { count: 3 } } })
+
+    const count = await postsService.fetchUnreadCount()
+
+    expect(api.get).toHaveBeenCalledWith('/api/intranet/posts/unread_count')
+    expect(count).toBe(3)
+  })
 })

--- a/tests/test_post_notification.py
+++ b/tests/test_post_notification.py
@@ -1,0 +1,60 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import os
+import sys
+import types
+
+# Minimal stub of Odoo
+odoo = types.ModuleType("odoo")
+class BaseModel:
+    @classmethod
+    def create(cls, vals_list):
+        return []
+odoo.models = types.SimpleNamespace(Model=BaseModel)
+odoo.fields = types.SimpleNamespace(Char=MagicMock(), Many2one=MagicMock(), Text=MagicMock(), Image=MagicMock(), Many2many=MagicMock(), One2many=MagicMock(), Selection=MagicMock(), Datetime=MagicMock(), Integer=MagicMock(), Boolean=MagicMock())
+odoo.api = types.SimpleNamespace(
+    model_create_multi=lambda f: f,
+    depends=lambda *args: (lambda f: f),
+)
+odoo._ = lambda x: x
+sys.modules['odoo'] = odoo
+sys.modules['odoo.models'] = odoo.models
+sys.modules['odoo.fields'] = odoo.fields
+sys.modules['odoo.api'] = odoo.api
+
+import importlib.util
+
+post_path = os.path.join(os.path.dirname(__file__), '..', 'models', 'post.py')
+spec = importlib.util.spec_from_file_location('models.post', post_path)
+post = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(post)
+sys.modules.setdefault('models.post', post)
+models_pkg = types.ModuleType('models')
+models_pkg.post = post
+post.models = types.SimpleNamespace(Model=odoo.models.Model)
+sys.modules.setdefault('models', models_pkg)
+
+class PostNotificationTest(unittest.TestCase):
+    def test_create_sends_bus_notification(self):
+        fake_env = MagicMock()
+        fake_bus = MagicMock()
+        fake_user_model = MagicMock()
+        fake_env.__getitem__.side_effect = lambda model: fake_bus if model == 'bus.bus' else fake_user_model
+        fake_user_model.search.return_value = MagicMock(mapped=MagicMock(return_value=[MagicMock(id=5)]))
+        fake_record = MagicMock()
+        fake_record.id = 1
+        fake_record.name = 't'
+        fake_record.user_id.name = 'u'
+        fake_record.create_date.strftime.return_value = 'd'
+        FakeSelf = type('FakeSelf', (post.IntranetPost,), {})
+        fake_self = FakeSelf()
+        fake_self.env = fake_env
+        fake_self._cr = MagicMock(dbname='x')
+        with patch('models.post.models.Model.create', return_value=[fake_record]):
+            post.IntranetPost.create(fake_self, [{'name': 't'}])
+        fake_bus.sendmany.assert_called_once()
+        args, _ = fake_bus.sendmany.call_args
+        self.assertEqual(args[0][0][1]['type'], 'new_post')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- notify all users when a post is created
- expose `/api/intranet/posts/unread_count` endpoint
- show unread post badge in sidebar
- reset notification count when posts are viewed
- add post notification context and hook
- test post notifications

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a308ad8a483298c628a1c4208091b