### PR TITLE
Add intranet admin role check

### DIFF
--- a/controllers/userApi_controller.py
+++ b/controllers/userApi_controller.py
@@ -24,7 +24,9 @@ class UserApiController(http.Controller):
 
         # Détermination des rôles
         roles = []
-        if user.has_group("gestion_patrimoine.group_patrimoine_admin"):
+        if user.has_group("gestion_patrimoine.group_intranet_admin"):
+            roles.append("admin_intranet")
+        elif user.has_group("gestion_patrimoine.group_patrimoine_admin"):
             roles.append("admin_patrimoine")
         elif user.has_group("base.group_system"):
             roles.append("admin")

--- a/tests/test_userApi_controller.py
+++ b/tests/test_userApi_controller.py
@@ -34,6 +34,24 @@ class UserApiControllerTest(unittest.TestCase):
         self.controller = user_api_controller.UserApiController()
 
     @patch('controllers.userApi_controller.request')
+    def test_get_user_info_intranet_admin(self, mock_request):
+        env = MagicMock()
+        employee_model = MagicMock()
+        env.__getitem__.return_value = employee_model
+        mock_request.env = env
+
+        user = MagicMock(id=30, name='IntrAdmin', login='intra')
+        user.has_group.side_effect = lambda g: g == 'gestion_patrimoine.group_intranet_admin'
+        env.user = user
+
+        employee_model.search.return_value = False
+
+        result = self.controller.get_user_info()
+
+        employee_model.search.assert_called_with([('user_id', '=', user.id)], limit=1)
+        self.assertEqual(result['roles'], ['admin_intranet'])
+
+    @patch('controllers.userApi_controller.request')
     def test_get_user_info_with_employee(self, mock_request):
         env = MagicMock()
         employee_model = MagicMock()


### PR DESCRIPTION
## Summary
- extend User API to detect intranet admin group before other admin checks
- append `admin_intranet` role when appropriate
- cover new role with unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a440de1288329a0c5ef3f3c224c20