### PR TITLE
Add intranet admin role

### DIFF
--- a/patrimoine-mtnd/src/components/app-sidebar.tsx
+++ b/patrimoine-mtnd/src/components/app-sidebar.tsx
@@ -40,7 +40,13 @@ export default function AppSidebar({ onCollapseChange }: AppSidebarProps) {
     }
 
     // Enhanced role checking with admin_patrimoine support
-    type UserRole = 'admin' | 'admin_patrimoine' | 'director' | 'agent' | 'user'
+    type UserRole =
+        | 'admin'
+        | 'admin_patrimoine'
+        | 'admin_intranet'
+        | 'director'
+        | 'agent'
+        | 'user'
     const hasRole = (role: UserRole) => {
         if (!currentUser) {
             console.warn('No current user found')
@@ -53,9 +59,12 @@ export default function AppSidebar({ onCollapseChange }: AppSidebarProps) {
         
         // Special case for admin roles
         if (checkRole === 'admin') {
-            return userRole === 'admin' ||
-                   userRole === 'admin_patrimoine' ||
-                   currentUser.is_admin
+            return (
+                userRole === 'admin' ||
+                userRole === 'admin_patrimoine' ||
+                userRole === 'admin_intranet' ||
+                currentUser.is_admin
+            )
         }
         
         return userRole === checkRole
@@ -111,11 +120,15 @@ export default function AppSidebar({ onCollapseChange }: AppSidebarProps) {
                     label: "Déclarations de Pertes",
                     path: "/admin/pertes",
                 },
-                {
-                    icon: <FileText className="h-5 w-5" />,
-                    label: "Tableau des posts",
-                    path: "/admin/posts",
-                },
+                ...(currentUser.role === 'admin_intranet'
+                    ? [
+                          {
+                              icon: <FileText className="h-5 w-5" />,
+                              label: "Tableau des posts",
+                              path: "/admin/posts",
+                          },
+                      ]
+                    : []),
             ],
         }] : []),
         ...(hasRole('director') ? [{


### PR DESCRIPTION
## Summary
- extend the allowed user roles in `AppSidebar`
- treat `admin_intranet` users as admins
- display the *Tableau des posts* entry only for intranet admins

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a4412b7088329a91115a3f75d636b