### PR TITLE
Allow admin_intranet posts

### DIFF
--- a/patrimoine-mtnd/src/pages/posts/PostsPage.jsx
+++ b/patrimoine-mtnd/src/pages/posts/PostsPage.jsx
@@ -13,7 +13,7 @@ import { usePostNotifications } from "@/context/PostNotificationContext"
 export default function PostsPage() {
     const { currentUser } = useAuth()
     const { setCount } = usePostNotifications()
-    const canCreate = ["admin_patrimoine", "admin", "agent"].includes(
+    const canCreate = ["admin_patrimoine", "admin_intranet", "admin", "agent"].includes(
         currentUser?.role
     )
     const [posts, setPosts] = useState([])

--- a/patrimoine-mtnd/src/tests/integration/postsPage.test.jsx
+++ b/patrimoine-mtnd/src/tests/integration/postsPage.test.jsx
@@ -186,5 +186,14 @@ describe('PostsPage behaviour', () => {
 
     const createBtn2 = Array.from(container.querySelectorAll('button')).find(b => b.textContent.includes('Faire un post'))
     expect(createBtn2).toBeDefined()
+
+    useAuth.mockReturnValueOnce({ currentUser: { role: 'admin_intranet' }, loading: false })
+    await act(async () => {
+      ReactDOM.createRoot(container).render(<PostsPage />)
+    })
+    await act(() => Promise.resolve())
+
+    const createBtn3 = Array.from(container.querySelectorAll('button')).find(b => b.textContent.includes('Faire un post'))
+    expect(createBtn3).toBeDefined()
   })
 })


### PR DESCRIPTION
## Summary
- let intranet admins create posts
- test post creation permissions for intranet admins

## Testing
- `pytest -q`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a441451808329881574ee5728b814