### PR TITLE
Fix replies when commenting on posts

### DIFF
--- a/patrimoine-mtnd/src/components/posts/Post.jsx
+++ b/patrimoine-mtnd/src/components/posts/Post.jsx
@@ -83,8 +83,12 @@ export default function Post({ post, onPostUpdate }) {
     const handleSendComment = async () => {
         if (!newComment.trim()) return
         try {
-            // 1. On appelle l'API. Elle renvoie le nouveau total de commentaires.
-            const response = await postsService.addComment(post.id, newComment)
+            // 1. On appelle l'API avec l'ID du commentaire parent s'il existe
+            const response = await postsService.addComment(
+                post.id,
+                newComment,
+                replyTo
+            )
 
             // 2. On utilise la fonction du parent pour mettre à jour l'état global
             onPostUpdate(post.id, {
@@ -99,11 +103,14 @@ export default function Post({ post, onPostUpdate }) {
                     user_name: currentUser.name,
                     create_date: new Date().toISOString(),
                     id: response.data.id, // On utilise l'ID renvoyé par l'API
+                    // On inclut l'ID du parent pour un affichage immédiat
+                    parent_id: replyTo,
                 },
             ])
 
-            // 4. On réinitialise le champ de saisie
+            // 4. On réinitialise le champ de saisie et la cible de la réponse
             setNewComment("")
+            setReplyTo(null)
         } catch (e) {
             console.error(e)
         }


### PR DESCRIPTION
## Summary
- ensure `replyTo` is sent when adding a comment
- reset the reply state after posting
- include parent id in newly added local comment

## Testing
- `pytest -q`
- `npm test --prefix patrimoine-mtnd` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a7c63a54483299091de2fdbde6c6f