### PR TITLE
Restrict admin routes to patrimoine admins

### DIFF
--- a/patrimoine-mtnd/src/App.jsx
+++ b/patrimoine-mtnd/src/App.jsx
@@ -98,7 +98,7 @@ function AppContent() {
               <Route
                   path="/admin/demandes"
                   element={
-                      <ProtectedRoute roles={[ROLES.ADMIN, ROLES.ADMIN_INTRANET]}>
+                      <ProtectedRoute roles={[ROLES.ADMIN]}>
                           <AdminDemandeMateriel />
                       </ProtectedRoute>
                   }
@@ -114,7 +114,7 @@ function AppContent() {
               <Route
                   path="/admin/pertes"
                   element={
-                      <ProtectedRoute roles={[ROLES.ADMIN, ROLES.ADMIN_INTRANET]}>
+                      <ProtectedRoute roles={[ROLES.ADMIN]}>
                           <AdminDeclarationsPerte />
                       </ProtectedRoute>
                   }


### PR DESCRIPTION
## Summary
- limit `/admin/demandes` and `/admin/pertes` to patrimoine admins only

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a87ad93288329b08acf26f75e2741