### PR TITLE
Add admin category management pages

### DIFF
--- a/patrimoine-mtnd/src/App.jsx
+++ b/patrimoine-mtnd/src/App.jsx
@@ -20,6 +20,8 @@ import AdminDeclarationsPerte from './pages/admin/AdminDeclarationsPerte';
 import AdminPostsPage from './pages/admin/AdminPostsPage';
 import PostDetailPage from './pages/admin/PostDetailPage';
 import AdminStatsPage from './pages/admin/AdminStatsPage';
+import AdminCategoriesPage from './pages/admin/AdminCategoriesPage';
+import AdminSubCategoriesPage from './pages/admin/AdminSubCategoriesPage';
 import DeclarationPerte from './pages/DeclarationPerte';
 import MyDeclarationsPage from './pages/user/MyDeclarationsPage';
 import DirDashboardPage from './pages/director/DirDashboardPage';
@@ -132,6 +134,22 @@ function AppContent() {
                   element={
                       <ProtectedRoute roles={[ROLES.ADMIN, ROLES.ADMIN_INTRANET]}>
                           <PostDetailPage />
+                      </ProtectedRoute>
+                  }
+              />
+              <Route
+                  path="/admin/categories"
+                  element={
+                      <ProtectedRoute roles={[ROLES.ADMIN, ROLES.ADMIN_INTRANET]}>
+                          <AdminCategoriesPage />
+                      </ProtectedRoute>
+                  }
+              />
+              <Route
+                  path="/admin/categories/:categoryId/subcategories"
+                  element={
+                      <ProtectedRoute roles={[ROLES.ADMIN, ROLES.ADMIN_INTRANET]}>
+                          <AdminSubCategoriesPage />
                       </ProtectedRoute>
                   }
               />

--- a/patrimoine-mtnd/src/pages/admin/AdminCategoriesPage.jsx
+++ b/patrimoine-mtnd/src/pages/admin/AdminCategoriesPage.jsx
@@ -1,0 +1,145 @@
+import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from "@/components/ui/table";
+import categoryService from "@/services/categoryService";
+import { toast } from "react-hot-toast";
+
+export default function AdminCategoriesPage() {
+    const [categories, setCategories] = useState([]);
+    const [form, setForm] = useState({ name: "", code: "", type: "" });
+    const [editingId, setEditingId] = useState(null);
+    const navigate = useNavigate();
+
+    const loadCategories = async () => {
+        try {
+            const data = await categoryService.getCategories();
+            const list = Array.isArray(data) ? data : data.data || [];
+            setCategories(list);
+        } catch (err) {
+            console.error(err);
+            toast.error("Erreur lors du chargement des catégories");
+        }
+    };
+
+    useEffect(() => {
+        loadCategories();
+    }, []);
+
+    const handleChange = e => {
+        setForm(prev => ({ ...prev, [e.target.name]: e.target.value }));
+    };
+
+    const resetForm = () => {
+        setForm({ name: "", code: "", type: "" });
+        setEditingId(null);
+    };
+
+    const handleSubmit = async e => {
+        e.preventDefault();
+        try {
+            if (editingId) {
+                await categoryService.updateCategory(editingId, form);
+                toast.success("Catégorie mise à jour");
+            } else {
+                await categoryService.createCategory(form);
+                toast.success("Catégorie créée");
+            }
+            resetForm();
+            loadCategories();
+        } catch (err) {
+            console.error(err);
+            toast.error("Échec de l'enregistrement");
+        }
+    };
+
+    const handleEdit = cat => {
+        setForm({ name: cat.name, code: cat.code, type: cat.type });
+        setEditingId(cat.id);
+    };
+
+    const handleDelete = async id => {
+        if (!window.confirm("Confirmer la suppression ?")) return;
+        try {
+            await categoryService.deleteCategory(id);
+            toast.success("Catégorie supprimée");
+            loadCategories();
+        } catch (err) {
+            console.error(err);
+            toast.error("Échec de la suppression");
+        }
+    };
+
+    return (
+        <div className="p-4 space-y-6">
+            <h1 className="text-2xl font-bold">Gestion des catégories</h1>
+            <form onSubmit={handleSubmit} className="space-y-2 max-w-md">
+                <Input
+                    name="name"
+                    placeholder="Nom"
+                    value={form.name}
+                    onChange={handleChange}
+                    required
+                />
+                <Input
+                    name="code"
+                    placeholder="Code"
+                    value={form.code}
+                    onChange={handleChange}
+                    required
+                />
+                <Input
+                    name="type"
+                    placeholder="Type"
+                    value={form.type}
+                    onChange={handleChange}
+                    required
+                />
+                <div className="flex gap-2">
+                    <Button type="submit">
+                        {editingId ? "Mettre à jour" : "Ajouter"}
+                    </Button>
+                    {editingId && (
+                        <Button type="button" variant="secondary" onClick={resetForm}>
+                            Annuler
+                        </Button>
+                    )}
+                </div>
+            </form>
+
+            <Table>
+                <TableHeader>
+                    <TableRow>
+                        <TableHead>Nom</TableHead>
+                        <TableHead>Code</TableHead>
+                        <TableHead>Type</TableHead>
+                        <TableHead>Actions</TableHead>
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
+                    {categories.map(cat => (
+                        <TableRow key={cat.id}>
+                            <TableCell>{cat.name}</TableCell>
+                            <TableCell>{cat.code}</TableCell>
+                            <TableCell>{cat.type}</TableCell>
+                            <TableCell className="space-x-2">
+                                <Button size="sm" onClick={() => handleEdit(cat)}>Éditer</Button>
+                                <Button size="sm" variant="destructive" onClick={() => handleDelete(cat.id)}>
+                                    Supprimer
+                                </Button>
+                                <Button
+                                    size="sm"
+                                    variant="secondary"
+                                    onClick={() => navigate(`/admin/categories/${cat.id}/subcategories`)}
+                                >
+                                    Sous-catégories
+                                </Button>
+                            </TableCell>
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+        </div>
+    );
+}

--- a/patrimoine-mtnd/src/pages/admin/AdminSubCategoriesPage.jsx
+++ b/patrimoine-mtnd/src/pages/admin/AdminSubCategoriesPage.jsx
@@ -1,0 +1,147 @@
+import React, { useState, useEffect } from "react";
+import { useParams, Link } from "react-router-dom";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from "@/components/ui/table";
+import categoryService from "@/services/categoryService";
+import { toast } from "react-hot-toast";
+
+export default function AdminSubCategoriesPage() {
+    const { categoryId } = useParams();
+    const [subcategories, setSubcategories] = useState([]);
+    const [category, setCategory] = useState(null);
+    const [form, setForm] = useState({ name: "", code: "" });
+    const [editingId, setEditingId] = useState(null);
+
+    const loadCategory = async () => {
+        try {
+            const data = await categoryService.getCategories();
+            const list = Array.isArray(data) ? data : data.data || [];
+            setCategory(list.find(c => String(c.id) === String(categoryId)) || null);
+        } catch (err) {
+            console.error(err);
+        }
+    };
+
+    const loadSubcategories = async () => {
+        try {
+            const data = await categoryService.getSubCategories(categoryId);
+            const list = Array.isArray(data) ? data : data.data || [];
+            setSubcategories(list);
+        } catch (err) {
+            console.error(err);
+            toast.error("Erreur de chargement");
+        }
+    };
+
+    useEffect(() => {
+        loadCategory();
+        loadSubcategories();
+    }, [categoryId]);
+
+    const handleChange = e => {
+        setForm(prev => ({ ...prev, [e.target.name]: e.target.value }));
+    };
+
+    const resetForm = () => {
+        setForm({ name: "", code: "" });
+        setEditingId(null);
+    };
+
+    const handleSubmit = async e => {
+        e.preventDefault();
+        try {
+            if (editingId) {
+                await categoryService.updateSubCategory(categoryId, editingId, form);
+                toast.success("Sous-catégorie mise à jour");
+            } else {
+                await categoryService.createSubCategory(categoryId, form);
+                toast.success("Sous-catégorie ajoutée");
+            }
+            resetForm();
+            loadSubcategories();
+        } catch (err) {
+            console.error(err);
+            toast.error("Échec de l'enregistrement");
+        }
+    };
+
+    const handleEdit = sub => {
+        setForm({ name: sub.name, code: sub.code });
+        setEditingId(sub.id);
+    };
+
+    const handleDelete = async id => {
+        if (!window.confirm("Confirmer la suppression ?")) return;
+        try {
+            await categoryService.deleteSubCategory(categoryId, id);
+            toast.success("Sous-catégorie supprimée");
+            loadSubcategories();
+        } catch (err) {
+            console.error(err);
+            toast.error("Échec de la suppression");
+        }
+    };
+
+    return (
+        <div className="p-4 space-y-6">
+            <div className="flex items-center justify-between">
+                <h1 className="text-2xl font-bold">
+                    Sous-catégories {category ? `de ${category.name}` : ""}
+                </h1>
+                <Button asChild variant="secondary">
+                    <Link to="/admin/categories">Retour</Link>
+                </Button>
+            </div>
+            <form onSubmit={handleSubmit} className="space-y-2 max-w-md">
+                <Input
+                    name="name"
+                    placeholder="Nom"
+                    value={form.name}
+                    onChange={handleChange}
+                    required
+                />
+                <Input
+                    name="code"
+                    placeholder="Code"
+                    value={form.code}
+                    onChange={handleChange}
+                    required
+                />
+                <div className="flex gap-2">
+                    <Button type="submit">
+                        {editingId ? "Mettre à jour" : "Ajouter"}
+                    </Button>
+                    {editingId && (
+                        <Button type="button" variant="secondary" onClick={resetForm}>
+                            Annuler
+                        </Button>
+                    )}
+                </div>
+            </form>
+            <Table>
+                <TableHeader>
+                    <TableRow>
+                        <TableHead>Nom</TableHead>
+                        <TableHead>Code</TableHead>
+                        <TableHead>Actions</TableHead>
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
+                    {subcategories.map(sub => (
+                        <TableRow key={sub.id}>
+                            <TableCell>{sub.name}</TableCell>
+                            <TableCell>{sub.code}</TableCell>
+                            <TableCell className="space-x-2">
+                                <Button size="sm" onClick={() => handleEdit(sub)}>Éditer</Button>
+                                <Button size="sm" variant="destructive" onClick={() => handleDelete(sub.id)}>
+                                    Supprimer
+                                </Button>
+                            </TableCell>
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- add `AdminCategoriesPage` and `AdminSubCategoriesPage` to manage categories
- integrate category pages with routing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aa186af9483299fed3e0e564a5086