### PR TITLE
Add dynamic custom field support when editing or creating assets

### DIFF
--- a/patrimoine-mtnd/src/services/fieldService.js
+++ b/patrimoine-mtnd/src/services/fieldService.js
@@ -27,6 +27,18 @@ export const getFields = async (subcategoryId) => {
   }
 };
 
+export const getFieldValues = async (itemId) => {
+  try {
+    const response = await axios.get(
+      `${getApiUrl()}/patrimoine/items/${itemId}/field-values`
+    );
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching field values:', error);
+    throw error;
+  }
+};
+
 export const createField = async (subcategoryId, fieldData) => {
   try {
     const response = await axios.post(


### PR DESCRIPTION
## Summary
- fetch custom field definitions from the API when a subcategory is selected
- show these inputs using `DynamicForm`
- save filled values with `fieldService.saveFieldValues`
- load existing values in edit mode
- expose `getFieldValues` helper in `fieldService`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aa18a66d88329aa9994101f787349