### PR TITLE
Add mouvement validation action

### DIFF
--- a/patrimoine-mtnd/src/pages/admin/AdminMouvement.jsx
+++ b/patrimoine-mtnd/src/pages/admin/AdminMouvement.jsx
@@ -131,12 +131,19 @@ function AdminMouvement() {
         e.preventDefault()
         try {
             const dataToSend = { ...formData }
-            await materialService.saveMouvement(dataToSend)
-            alert("Mouvement enregistré avec succès !")
+            const result = await materialService.saveMouvement(dataToSend)
+            const mouvementId = result?.mouvement_id
+            if (mouvementId) {
+                await materialService.validateMouvement(mouvementId)
+                await materialService.fetchMaterialDetails(formData.asset_id)
+                toast.success("Mouvement validé avec succès !")
+            } else {
+                toast.success("Mouvement enregistré avec succès !")
+            }
             navigate(-1)
         } catch (error) {
             console.error("Erreur lors de l'enregistrement:", error)
-            alert(error.message || "Échec de l'enregistrement.")
+            toast.error(error.response?.data?.message || error.message || "Échec de l'enregistrement.")
         }
     }
 

--- a/patrimoine-mtnd/src/services/materialService.js
+++ b/patrimoine-mtnd/src/services/materialService.js
@@ -69,6 +69,10 @@ const updateItem = (id, formData) =>
         .then(res => res.data)
 const saveMouvement = mouvementData =>
     api.post("/api/patrimoine/mouvements", mouvementData).then(res => res.data)
+const validateMouvement = mouvementId =>
+    api
+        .post(`/api/patrimoine/mouvements/${mouvementId}/validate`)
+        .then(res => res.data)
 const createDemande = demandeData =>
     api.post("/api/patrimoine/demandes", demandeData).then(res => res.data)
 const createPerte = perteData =>
@@ -150,6 +154,7 @@ export default {
     createItem,
     updateItem,
     saveMouvement,
+    validateMouvement,
     createDemande,
     createPerte,
     processDemande,


### PR DESCRIPTION
## Summary
- add `validateMouvement` API call in material service
- call validation endpoint after saving a mouvement
- refresh asset information and show feedback

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687aa18e95dc8329960ba03939fe553e