### PR TITLE
Add panne declaration and validation features

### DIFF
--- a/patrimoine-mtnd/src/App.jsx
+++ b/patrimoine-mtnd/src/App.jsx
@@ -23,8 +23,10 @@ import AdminStatsPage from './pages/admin/AdminStatsPage';
 import AdminCategoriesPage from './pages/admin/AdminCategoriesPage';
 import AdminSubCategoriesPage from './pages/admin/AdminSubCategoriesPage';
 import DeclarationPerte from './pages/DeclarationPerte';
+import DeclarationPanne from './pages/DeclarationPanne';
 import MyDeclarationsPage from './pages/user/MyDeclarationsPage';
 import DirDashboardPage from './pages/director/DirDashboardPage';
+import ManagerValidationPanne from './pages/manager/ManagerValidationPanne';
 import UnauthorizedPage from './pages/UnauthorizedPage'; // N'oubliez pas l'import
 import ChatPage from './pages/chat/ChatPage';
 import PostsPage from './pages/posts/PostsPage';
@@ -205,6 +207,14 @@ function AppContent() {
                       </ProtectedRoute>
                   }
               />
+              <Route
+                  path="/manager/validation-pannes"
+                  element={
+                      <ProtectedRoute roles={[ROLES.MANAGER, ROLES.ADMIN, ROLES.ADMIN_INTRANET]}>
+                          <ManagerValidationPanne />
+                      </ProtectedRoute>
+                  }
+              />
 
               {/* --- Route pour les pages agent --- */}
               {/* Tous les utilisateurs connectés ayant un rôle peuvent voir leur dashboard */}
@@ -240,6 +250,22 @@ function AppContent() {
                           ]}
                       >
                           <DeclarationPerte />
+                      </ProtectedRoute>
+                  }
+              />
+              <Route
+                  path="declaration-pannes"
+                  element={
+                      <ProtectedRoute
+                          roles={[
+                              ROLES.AGENT,
+                              ROLES.MANAGER,
+                              ROLES.DIRECTOR,
+                              ROLES.ADMIN,
+                              ROLES.ADMIN_INTRANET,
+                          ]}
+                      >
+                          <DeclarationPanne />
                       </ProtectedRoute>
                   }
               />

--- a/patrimoine-mtnd/src/components/app-sidebar.tsx
+++ b/patrimoine-mtnd/src/components/app-sidebar.tsx
@@ -171,6 +171,16 @@ export default function AppSidebar({ onCollapseChange }: AppSidebarProps) {
                 },
             ],
         }] : []),
+        ...(hasRole('manager') ? [{
+            section: "Manager",
+            items: [
+                {
+                    icon: <CheckSquare className="h-5 w-5" />,
+                    label: "Validation Pannes",
+                    path: "/manager/validation-pannes",
+                },
+            ],
+        }] : []),
         ...(hasRole('agent') ? [{
             section: "Agent",
             items: [
@@ -183,6 +193,11 @@ export default function AppSidebar({ onCollapseChange }: AppSidebarProps) {
                     icon: <AlertCircle className="h-5 w-5" />,
                     label: "Déclarer Perte",
                     path: "/declaration-pertes",
+                },
+                {
+                    icon: <AlertCircle className="h-5 w-5" />,
+                    label: "Déclarer Panne",
+                    path: "/declaration-pannes",
                 },
             ],
         }] : []),

--- a/patrimoine-mtnd/src/pages/DeclarationPanne.jsx
+++ b/patrimoine-mtnd/src/pages/DeclarationPanne.jsx
@@ -1,0 +1,120 @@
+import React, { useEffect, useState } from "react"
+import { useNavigate } from "react-router-dom"
+import { toast } from "react-hot-toast"
+import Select from "react-select"
+import makeAnimated from "react-select/animated"
+import materialService from "@/services/materialService"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+
+const animatedComponents = makeAnimated()
+
+const customStyles = {
+    control: (base, state) => ({
+        ...base,
+        borderWidth: "1px",
+        borderRadius: "0.5rem",
+        padding: "0.25rem",
+        backgroundColor: "white",
+        borderColor: state.isFocused ? "#f97316" : "#d1d5db",
+        boxShadow: state.isFocused ? "0 0 0 2px rgba(249,115,22,0.5)" : "none",
+        "&:hover": { borderColor: "#fb923c" },
+        transition: "all 0.2s ease",
+    }),
+    option: (base, state) => ({
+        ...base,
+        backgroundColor: state.isFocused ? "#fed7aa" : "white",
+        color: "#1f2937",
+        "&:hover": { backgroundColor: "#fb923c", color: "white" },
+        cursor: "pointer",
+    }),
+    singleValue: base => ({
+        ...base,
+        color: "#1f2937",
+    }),
+    menu: base => ({
+        ...base,
+        zIndex: 9999,
+    }),
+}
+
+export default function DeclarationPanne() {
+    const navigate = useNavigate()
+    const [assets, setAssets] = useState([])
+    const [loading, setLoading] = useState(true)
+    const [formData, setFormData] = useState({ asset_id: "", description: "" })
+
+    useEffect(() => {
+        materialService
+            .fetchMaterialsByUser()
+            .then(setAssets)
+            .catch(() => toast.error("Impossible de charger vos matériels."))
+            .finally(() => setLoading(false))
+    }, [])
+
+    const handleSubmit = async e => {
+        e.preventDefault()
+        if (!formData.asset_id || !formData.description.trim()) {
+            toast.error("Veuillez sélectionner le matériel et décrire la panne.")
+            return
+        }
+        try {
+            await materialService.createPanne(formData)
+            toast.success("Panne déclarée avec succès.")
+            navigate("/agent")
+        } catch (err) {
+            toast.error(`Erreur lors de la déclaration : ${err.message}`)
+        }
+    }
+
+    return (
+        <div className="min-h-screen w-full p-4 sm:p-6 lg:p-8">
+            <div className="max-w-xl mx-auto space-y-6">
+                <h1 className="text-2xl font-bold">Déclaration de Panne</h1>
+                <form onSubmit={handleSubmit} className="space-y-4">
+                    <div>
+                        <Label htmlFor="asset" className="font-semibold text-black">
+                            Matériel concerné *
+                        </Label>
+                        <Select
+                            inputId="asset"
+                            styles={customStyles}
+                            components={animatedComponents}
+                            options={assets.map(a => ({ value: a.id, label: a.name }))}
+                            onChange={opt =>
+                                setFormData(prev => ({ ...prev, asset_id: opt?.value || "" }))
+                            }
+                            isDisabled={loading}
+                            placeholder="Choisir un matériel"
+                        />
+                    </div>
+                    <div>
+                        <Label htmlFor="description" className="font-semibold text-black">
+                            Description de la panne *
+                        </Label>
+                        <Textarea
+                            id="description"
+                            required
+                            rows={4}
+                            value={formData.description}
+                            onChange={e =>
+                                setFormData(prev => ({ ...prev, description: e.target.value }))
+                            }
+                            placeholder="Décrivez la panne rencontrée..."
+                            className="w-full text-black p-2.5 border border-slate-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-orange-500 hover:border-orange-400 transition duration-200"
+                        />
+                    </div>
+                    <div className="flex justify-end space-x-4 pt-2">
+                        <Button type="button" variant="outline" onClick={() => navigate(-1)}>
+                            Annuler
+                        </Button>
+                        <Button type="submit" disabled={loading} className="bg-orange-500 hover:bg-orange-600 text-white">
+                            Soumettre
+                        </Button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    )
+}

--- a/patrimoine-mtnd/src/pages/manager/ManagerValidationPanne.jsx
+++ b/patrimoine-mtnd/src/pages/manager/ManagerValidationPanne.jsx
@@ -1,0 +1,150 @@
+import React, { useEffect, useState, useRef } from "react"
+import { toast } from "react-hot-toast"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import {
+    Table,
+    TableHeader,
+    TableBody,
+    TableRow,
+    TableHead,
+    TableCell,
+} from "@/components/ui/table"
+import { Printer } from "lucide-react"
+import materialService from "@/services/materialService"
+
+export default function ManagerValidationPanne() {
+    const [declarations, setDeclarations] = useState([])
+    const [loading, setLoading] = useState(true)
+    const [error, setError] = useState(null)
+    const tableRef = useRef()
+
+    const loadDeclarations = () => {
+        setLoading(true)
+        materialService
+            .fetchPannesForManager()
+            .then(data => setDeclarations(Array.isArray(data) ? data : []))
+            .catch(err => {
+                setError("Erreur de chargement des déclarations.")
+                console.error(err)
+            })
+            .finally(() => setLoading(false))
+    }
+
+    useEffect(() => {
+        loadDeclarations()
+    }, [])
+
+    const handleProcess = async (id, action) => {
+        try {
+            await materialService.processPanneForManager(id, action)
+            toast.success(
+                `Déclaration ${action === "approve" ? "validée" : "rejetée"}.`
+            )
+            loadDeclarations()
+        } catch (err) {
+            toast.error(`Échec de l'opération: ${err.message}`)
+        }
+    }
+
+    const handlePrint = () => {
+        const content = tableRef.current
+        if (!content) return
+        const w = window.open("", "_blank", "height=800,width=1000")
+        w.document.write("<html><head><title>Liste des Pannes</title>")
+        Array.from(document.querySelectorAll('link[rel="stylesheet"], style')).forEach(link => {
+            w.document.head.appendChild(link.cloneNode(true))
+        })
+        w.document.write("</head><body>")
+        w.document.write(content.innerHTML)
+        w.document.write("</body></html>")
+        w.document.close()
+        setTimeout(() => {
+            w.focus()
+            w.print()
+            w.close()
+        }, 500)
+    }
+
+    const getStatusBadge = status => {
+        const statusMap = {
+            draft: { label: "Brouillon", variant: "outline" },
+            to_approve: { label: "En attente", variant: "secondary" },
+            approved: { label: "Approuvée", className: "bg-green-500 text-white" },
+            rejected: { label: "Rejetée", variant: "destructive" },
+        }
+        const { label, ...props } = statusMap[status] || {
+            label: status,
+            variant: "outline",
+        }
+        return <Badge {...props}>{label}</Badge>
+    }
+
+    if (loading) return <div className="p-8 text-center">Chargement...</div>
+    if (error) return <div className="p-8 text-center text-red-500">{error}</div>
+
+    return (
+        <div className="container mx-auto p-4 sm:p-6 lg:p-8">
+            <div className="mb-8">
+                <h1 className="text-3xl font-bold text-center">
+                    Validation des Déclarations de Panne
+                </h1>
+            </div>
+            <Button
+                onClick={handlePrint}
+                variant="outline"
+                className="hover:bg-orange-500 hover:text-white"
+            >
+                <Printer className="h-4 w-4 mr-2" />
+                Imprimer le tableau
+            </Button>
+            <div ref={tableRef} className="rounded-md border mt-4">
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead>Déclaré par</TableHead>
+                            <TableHead>Matériel</TableHead>
+                            <TableHead>Statut</TableHead>
+                            <TableHead className="text-right">Actions</TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {declarations.length > 0 ? (
+                            declarations.map(panne => (
+                                <TableRow key={panne.id}>
+                                    <TableCell className="font-medium">
+                                        {panne.declarer_par_name}
+                                    </TableCell>
+                                    <TableCell>{panne.asset_name}</TableCell>
+                                    <TableCell>{getStatusBadge(panne.state)}</TableCell>
+                                    <TableCell className="text-right space-x-2">
+                                        <Button
+                                            size="sm"
+                                            className="bg-green-600 hover:bg-green-700"
+                                            onClick={() => handleProcess(panne.id, "approve")}
+                                        >
+                                            Confirmer
+                                        </Button>
+                                        <Button
+                                            variant="destructive"
+                                            size="sm"
+                                            onClick={() => handleProcess(panne.id, "reject")}
+                                        >
+                                            Rejeter
+                                        </Button>
+                                    </TableCell>
+                                </TableRow>
+                            ))
+                        ) : (
+                            <TableRow>
+                                <TableCell colSpan="4" className="h-24 text-center text-gray-500">
+                                    Aucune déclaration en attente.
+                                </TableCell>
+                            </TableRow>
+                        )}
+                    </TableBody>
+                </Table>
+            </div>
+        </div>
+    )
+}

--- a/patrimoine-mtnd/src/services/apiConfig.js
+++ b/patrimoine-mtnd/src/services/apiConfig.js
@@ -93,6 +93,12 @@ export const apiConfig = {
         PERTES_CREATE: "/api/patrimoine/pertes",
         PERTES_LIST: "/api/patrimoine/pertes",
         PERTES_PROCESS: perteId => `/api/patrimoine/pertes/${perteId}/process`,
+        PANNES_CREATE: "/api/patrimoine/pannes",
+        PANNES_LIST: "/api/patrimoine/pannes",
+        PANNES_PROCESS: panneId => `/api/patrimoine/pannes/${panneId}/process`,
+        PANNES_MANAGER_LIST: "/api/patrimoine/pannes/manager",
+        PANNES_MANAGER_PROCESS: panneId =>
+            `/api/patrimoine/pannes/manager_process/${panneId}`,
         STATS_BY_DEPARTMENT: "/api/patrimoine/stats/by_department",
         STATS_FOR_DEPARTMENT: deptId =>
             `/api/patrimoine/stats/department/${deptId}`,

--- a/patrimoine-mtnd/src/services/materialService.js
+++ b/patrimoine-mtnd/src/services/materialService.js
@@ -52,6 +52,10 @@ const fetchDeclarationsPerte = () =>
     api.get("/api/patrimoine/pertes").then(res => res.data)
 const fetchPertesForManager = () =>
     api.get("/api/patrimoine/pertes/manager").then(res => res.data)
+const fetchPannes = () =>
+    api.get("/api/patrimoine/pannes").then(res => res.data)
+const fetchPannesForManager = () =>
+    api.get("/api/patrimoine/pannes/manager").then(res => res.data)
 
 // --- Fonctions de Création et Mise à Jour (POST, PUT) ---
 
@@ -81,6 +85,8 @@ const createPerte = perteData =>
             headers: { "Content-Type": "multipart/form-data" },
         })
         .then(res => res.data)
+const createPanne = panneData =>
+    api.post("/api/patrimoine/pannes", panneData).then(res => res.data)
 
 // --- Fonctions de Traitement de Workflow (POST) ---
 
@@ -95,6 +101,14 @@ const processPerte = (perteId, action) =>
 const processPerteForManager = (perteId, action) =>
     api
         .post(`/api/patrimoine/pertes/manager_process/${perteId}`, { action })
+        .then(res => res.data)
+const processPanne = (panneId, action) =>
+    api
+        .post(`/api/patrimoine/pannes/${panneId}/process`, { action })
+        .then(res => res.data)
+const processPanneForManager = (panneId, action) =>
+    api
+        .post(`/api/patrimoine/pannes/manager_process/${panneId}`, { action })
         .then(res => res.data)
 
 // --- Fonctions pour les Statistiques ---
@@ -150,6 +164,8 @@ export default {
     fetchDemandeDetails,
     fetchDeclarationsPerte,
     fetchPertesForManager,
+    fetchPannes,
+    fetchPannesForManager,
     getMaterialsByDepartment,
     createItem,
     updateItem,
@@ -157,9 +173,12 @@ export default {
     validateMouvement,
     createDemande,
     createPerte,
+    createPanne,
     processDemande,
     processPerte,
     processPerteForManager,
+    processPanne,
+    processPanneForManager,
     fetchStats,
     fetchAllDepartmentStats,
     fetchStatsForOneDepartment,


### PR DESCRIPTION
## Summary
- implement a simple page to declare a panne
- add manager page for validating pannes
- support panne API endpoints
- expose new service methods
- link new pages from the sidebar and routes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b59f1227883298aef5dae4c5e8617