### PR TITLE
Add panne management features

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -23,6 +23,7 @@
         "views/intranet_post_views.xml",
         "views/menu.xml",
         "views/mouvement_views.xml",
+        "views/panne_views.xml",
         "views/perte_views.xml",
         "views/demande_materiel_views.xml",
         "views/asset_category_views.xml",

--- a/controllers/asset_controller.py
+++ b/controllers/asset_controller.py
@@ -2555,3 +2555,160 @@ class PatrimoineAssetController(http.Controller):
         except Exception as e:
             _logger.error("Error processing perte %s: %s", perte_id, str(e))
             return {"status": "error", "message": str(e)}
+
+    # --- API pour créer un signalement de panne ---
+    @http.route(
+        "/api/patrimoine/pannes",
+        auth="user",
+        type="http",
+        methods=["POST"],
+        csrf=False,
+    )
+    def create_panne(self, **post):
+        try:
+            post = request.httprequest.form.to_dict()
+            current_user = request.env.user
+            if not current_user.has_group("gestion_patrimoine.group_patrimoine_agent") and not current_user.has_group(
+                "gestion_patrimoine.group_patrimoine_director"
+            ):
+                raise AccessError(
+                    "Accès refusé. Seuls les agents et directeurs peuvent créer des signalements de panne."
+                )
+
+            asset_id = post.get("asset_id")
+            description = post.get("description")
+            date_panne = post.get("date_panne")
+
+            if not asset_id or not description:
+                raise ValidationError("Asset ou description manquant.")
+
+            asset = request.env["patrimoine.asset"].browse(int(asset_id))
+            if not asset.exists():
+                raise ValidationError("Bien concerné non trouvé.")
+
+            panne_vals = {
+                "asset_id": int(asset_id),
+                "description": description,
+                "date_panne": date_panne,
+                "declarer_par_id": current_user.id,
+                "state": "to_approve",
+            }
+
+            new_panne = request.env["patrimoine.panne"].create(panne_vals)
+            new_panne.action_submit()
+
+            return Response(
+                json.dumps({"status": "success", "panne_id": new_panne.id, "panne_name": new_panne.name}, default=str),
+                headers=CORS_HEADERS,
+            )
+        except Exception as e:
+            _logger.error(f"Erreur lors de la création du signalement de panne : {e}")
+            return Response(json.dumps({"error": str(e)}), status=500, headers=CORS_HEADERS, content_type="application/json")
+
+    # --- API pour lister les pannes ---
+    @http.route("/api/patrimoine/pannes", auth="user", type="http", methods=["GET"])
+    def list_pannes(self, **kw):
+        try:
+            pannes = request.env["patrimoine.panne"].search([], order="date_panne desc")
+            data = []
+            for panne in pannes:
+                data.append(
+                    {
+                        "id": panne.id,
+                        "name": panne.name,
+                        "asset_id": panne.asset_id.id,
+                        "asset_name": panne.asset_id.name,
+                        "date_panne": panne.date_panne.strftime("%Y-%m-%d") if panne.date_panne else None,
+                        "description": panne.description,
+                        "declarer_par_id": panne.declarer_par_id.id,
+                        "declarer_par_name": panne.declarer_par_id.name,
+                        "state": panne.state,
+                    }
+                )
+            return Response(json.dumps(data), headers={"Content-Type": "application/json"})
+        except Exception as e:
+            _logger.error("Error listing pannes: %s", str(e))
+            return Response(json.dumps({"status": "error", "message": str(e)}), status=500, headers={"Content-Type": "application/json"})
+
+    @http.route("/api/patrimoine/pannes/manager", auth="user", type="http", methods=["GET"])
+    def list_pannes_for_manager(self, **kw):
+        try:
+            current_employee = request.env["hr.employee"].search([("user_id", "=", request.env.user.id)], limit=1)
+            if not current_employee:
+                return Response(json.dumps([]), headers={"Content-Type": "application/json"})
+
+            employee_ids = request.env["hr.employee"].search([("parent_id", "=", current_employee.id)]).ids
+            if not employee_ids and current_employee.department_id:
+                employee_ids = request.env["hr.employee"].search([("department_id", "=", current_employee.department_id.id)]).ids
+
+            user_ids_of_team = request.env["hr.employee"].browse(employee_ids).mapped("user_id").ids
+            domain = [("declarer_par_id", "in", user_ids_of_team), ("state", "=", "to_approve")]
+
+            pannes = request.env["patrimoine.panne"].search(domain, order="date_panne desc")
+            data = []
+            for panne in pannes:
+                data.append(
+                    {
+                        "id": panne.id,
+                        "name": panne.name,
+                        "asset_name": panne.asset_id.sudo().name,
+                        "declarer_par_name": panne.declarer_par_id.name,
+                        "date_panne": panne.date_panne.strftime("%Y-%m-%d") if panne.date_panne else None,
+                        "state": panne.state,
+                    }
+                )
+            return Response(json.dumps(data), headers={"Content-Type": "application/json"})
+        except Exception as e:
+            _logger.error(f"Error listing pannes for manager {request.env.user.name}: {e}")
+            return Response(json.dumps({"error": str(e)}), status=500, headers={"Content-Type": "application/json"})
+
+    @http.route("/api/patrimoine/pannes/manager_process/<int:panne_id>", auth="user", type="json", methods=["POST"])
+    def manager_process_panne(self, panne_id, action, **kw):
+        try:
+            panne = request.env["patrimoine.panne"].browse(panne_id)
+            if not panne.exists():
+                return {"status": "error", "message": "Déclaration non trouvée"}
+
+            current_employee = request.env["hr.employee"].search([("user_id", "=", request.env.user.id)], limit=1)
+            if panne.declarer_par_id.employee_ids and panne.declarer_par_id.employee_ids[0].parent_id != current_employee:
+                return {"status": "error", "message": "Action non autorisée."}
+
+            if action == "approve":
+                panne.action_manager_approve()
+            elif action == "reject":
+                panne.action_reject()
+            else:
+                return {"status": "error", "message": "Action invalide"}
+
+            return {"status": "success", "new_state": panne.state}
+        except Exception as e:
+            _logger.error(f"Error processing panne {panne_id} by manager: {e}")
+            return {"status": "error", "message": str(e)}
+
+    @http.route("/api/patrimoine/pannes/<int:panne_id>/process", auth="user", type="json", methods=["POST"], csrf=False)
+    def process_panne(self, panne_id, action, **kw):
+        try:
+            panne = request.env["patrimoine.panne"].browse(panne_id)
+            if not panne.exists():
+                return {"status": "error", "message": "Signalement non trouvé"}
+
+            if not request.env.user.has_group("gestion_patrimoine.group_patrimoine_admin"):
+                raise AccessError("Accès refusé. Seul un administrateur du patrimoine peut traiter les pannes.")
+
+            if action == "approve":
+                panne.action_approve()
+            elif action == "reject":
+                panne.action_reject()
+            else:
+                return {"status": "error", "message": "Action invalide"}
+
+            return {"status": "success", "new_state": panne.state}
+        except AccessError as e:
+            _logger.error("Access denied processing panne %s: %s", panne_id, str(e))
+            return {"status": "error", "message": f"Accès refusé: {e.name}"}
+        except ValidationError as e:
+            _logger.error("Validation error processing panne %s: %s", panne_id, str(e))
+            return {"status": "error", "message": f"Erreur de validation: {e.name}"}
+        except Exception as e:
+            _logger.error("Error processing panne %s: %s", panne_id, str(e))
+            return {"status": "error", "message": str(e)}

--- a/data/sequence.xml
+++ b/data/sequence.xml
@@ -37,4 +37,13 @@
         <field name="number_increment">1</field>
     </record>
 
+    <record id="seq_patrimoine_panne" model="ir.sequence">
+        <field name="name">Signalement Panne</field>
+        <field name="code">patrimoine.panne.code</field>
+        <field name="prefix">PANNE/%(year)s/</field>
+        <field name="padding">4</field>
+        <field name="number_next">1</field>
+        <field name="number_increment">1</field>
+    </record>
+
 </odoo>

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -15,6 +15,7 @@ from . import fiche_vie
 from . import demande_materiel
 from . import demande_materiel_ligne
 from . import pertes
+from . import panne
 from . import chat
 from . import post
 from . import chat_test

--- a/models/panne.py
+++ b/models/panne.py
@@ -1,0 +1,86 @@
+from odoo import models, fields, api, _
+
+
+class PatrimoinePanne(models.Model):
+    _name = "patrimoine.panne"
+    _description = "Signalement de Panne"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
+
+    name = fields.Char(
+        string="Référence",
+        required=True,
+        copy=False,
+        readonly=True,
+        default=lambda self: _("Nouveau"),
+    )
+    asset_id = fields.Many2one(
+        "patrimoine.asset", string="Bien Concerné", required=True, tracking=True
+    )
+    description = fields.Text(string="Description", required=True, tracking=True)
+    date_panne = fields.Date(
+        string="Date de la panne",
+        required=True,
+        default=fields.Date.context_today,
+        tracking=True,
+    )
+    declarer_par_id = fields.Many2one(
+        "res.users",
+        string="Déclaré par",
+        required=True,
+        default=lambda self: self.env.user,
+        readonly=True,
+    )
+    manager_id = fields.Many2one(
+        "hr.employee", string="Manager", compute="_compute_manager", store=True
+    )
+    state = fields.Selection(
+        [
+            ("draft", "Brouillon"),
+            ("to_approve", "En attente de validation Manager"),
+            ("manager_approved", "En attente de validation Admin"),
+            ("approved", "Approuvée"),
+            ("rejected", "Rejetée"),
+        ],
+        string="Statut",
+        default="draft",
+        required=True,
+        tracking=True,
+    )
+
+    @api.model
+    def create(self, vals_list):
+        if vals_list.get("name", _("Nouveau")) == _("Nouveau"):
+            vals_list["name"] = self.env["ir.sequence"].next_by_code(
+                "patrimoine.panne.code"
+            ) or _("Nouveau")
+        record = super().create(vals_list)
+        partner = record.manager_id.user_id.partner_id if record.manager_id else None
+        if partner:
+            payload = {
+                "type": "new_panne",
+                "id": record.id,
+                "asset_name": record.asset_id.name,
+                "description": record.description,
+            }
+            self.env["bus.bus"].sendmany([(partner, payload)])
+        return record
+
+    @api.depends("declarer_par_id")
+    def _compute_manager(self):
+        for rec in self:
+            employee = self.env["hr.employee"].search(
+                [("user_id", "=", rec.declarer_par_id.id)], limit=1
+            )
+            rec.manager_id = employee.parent_id if employee else False
+
+    def action_submit(self):
+        self.write({"state": "to_approve"})
+
+    def action_manager_approve(self):
+        self.write({"state": "manager_approved"})
+
+    def action_approve(self):
+        self.write({"state": "approved"})
+
+    def action_reject(self):
+        self.write({"state": "rejected"})

--- a/security/ir.model.access.csv
+++ b/security/ir.model.access.csv
@@ -20,6 +20,9 @@ access_fiche_vie_admin,access.fiche.vie.admin,model_patrimoine_fiche_vie,gestion
 access_perte_admin,access.perte.admin,model_patrimoine_perte,gestion_patrimoine.group_patrimoine_admin,1,1,1,1
 access_demande_materiel_admin,access.demande.materiel.admin,model_patrimoine_demande_materiel,gestion_patrimoine.group_patrimoine_admin,1,1,1,1
 
+access_panne_admin,access.panne.admin,model_patrimoine_panne,gestion_patrimoine.group_patrimoine_admin,1,1,1,1
+access_panne_director,access.panne.director,model_patrimoine_panne,gestion_patrimoine.group_patrimoine_director,1,1,1,0
+
 
 access_asset_director,access.asset.director,model_patrimoine_asset,gestion_patrimoine.group_patrimoine_director,1,1,1,0
 access_mouvement_director,access.mouvement.director,model_patrimoine_mouvement,gestion_patrimoine.group_patrimoine_director,1,1,1,0
@@ -36,6 +39,7 @@ access_asset_agent,access.asset.agent,model_patrimoine_asset,gestion_patrimoine.
 access_mouvement_agent,access.mouvement.agent,model_patrimoine_mouvement,gestion_patrimoine.group_patrimoine_agent,1,0,0,0
 access_entretien_agent,access.entretien.agent,model_patrimoine_entretien,gestion_patrimoine.group_patrimoine_agent,1,0,0,0
 access_perte_agent,access.perte.agent,model_patrimoine_perte,gestion_patrimoine.group_patrimoine_agent,1,1,1,0
+access_panne_agent,access.panne.agent,model_patrimoine_panne,gestion_patrimoine.group_patrimoine_agent,1,1,1,0
 access_chat_conversation_admin,access.chat.conversation.admin,model_chat_conversation,gestion_patrimoine.group_patrimoine_admin,1,1,1,1
 access_chat_conversation_director,access.chat.conversation.director,model_chat_conversation,gestion_patrimoine.group_patrimoine_director,1,1,1,1
 access_chat_conversation_agent,access.chat.conversation.agent,model_chat_conversation,gestion_patrimoine.group_patrimoine_agent,1,1,1,0

--- a/security/record_rules.xml
+++ b/security/record_rules.xml
@@ -150,9 +150,33 @@
                 eval="1"/>
         </record>
 
+        <record id="rule_panne_agent_create" model="ir.rule">
+            <field name="name">Agent - Déclarer panne</field>
+            <field name="model_id" ref="model_patrimoine_panne"/>
+            <field name="groups" eval="[(4, ref('gestion_patrimoine.group_patrimoine_agent'))]"/>
+            <field name="domain_force">[('asset_id.employee_id.user_id', '=', user.id)]</field>
+            <field name="perm_read" eval="1"/>
+            <field name="perm_create" eval="1"/>
+        </record>
+
         <record id="rule_perte_director_access" model="ir.rule">
             <field name="name">Directeur - Déclarations pertes équipe</field>
             <field name="model_id" ref="model_patrimoine_perte"/>
+            <field name="groups" eval="[(4, ref('gestion_patrimoine.group_patrimoine_director'))]"/>
+            <field name="domain_force">
+                ['|',
+                 ('declarer_par_id', '=', user.id),
+                 ('declarer_par_id.employee_ids.department_id', '=', user.employee_id.department_id.id)
+                ]
+            </field>
+            <field name="perm_read" eval="1"/>
+            <field name="perm_write" eval="1"/>
+            <field name="perm_create" eval="1"/>
+        </record>
+
+        <record id="rule_panne_director_access" model="ir.rule">
+            <field name="name">Directeur - Signalements panne équipe</field>
+            <field name="model_id" ref="model_patrimoine_panne"/>
             <field name="groups" eval="[(4, ref('gestion_patrimoine.group_patrimoine_director'))]"/>
             <field name="domain_force">
                 ['|',

--- a/views/menu.xml
+++ b/views/menu.xml
@@ -8,6 +8,7 @@
     <menuitem id="menu_patrimoine_assets" name="Biens" parent="menu_patrimoine_root" sequence="10"/>
     <menuitem id="menu_patrimoine_mouvements" name="Mouvements" parent="menu_patrimoine_root" sequence="20"/>
     <menuitem id="menu_patrimoine_entretiens" name="Entretiens" parent="menu_patrimoine_root" sequence="30"/>
+    <menuitem id="menu_patrimoine_panne" name="Signalements de panne" parent="menu_patrimoine_root" action="action_panne" sequence="31"/>
     <menuitem id="menu_intranet_posts" name="Posts" parent="menu_patrimoine_root" action="action_intranet_post" sequence="40"/>
     <menuitem id="menu_patrimoine_config" name="Configuration" parent="menu_patrimoine_root" sequence="100"/>
 </odoo>

--- a/views/panne_views.xml
+++ b/views/panne_views.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_panne_tree" model="ir.ui.view">
+        <field name="name">patrimoine.panne.tree</field>
+        <field name="model">patrimoine.panne</field>
+        <field name="arch" type="xml">
+            <tree string="Signalements de panne">
+                <field name="state" widget="statusbar" statusbar_visible="draft,to_approve,manager_approved,approved,rejected"/>
+                <field name="name" string="Référence"/>
+                <field name="asset_id" string="Bien concerné"/>
+                <field name="date_panne" string="Date"/>
+                <field name="declarer_par_id" string="Déclarant"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="action_panne_my" model="ir.actions.act_window">
+        <field name="name">Mes signalements</field>
+        <field name="res_model">patrimoine.panne</field>
+        <field name="view_mode">tree,form</field>
+        <field name="domain">[("declarer_par_id", "=", uid)]</field>
+    </record>
+
+    <record id="view_panne_form" model="ir.ui.view">
+        <field name="name">patrimoine.panne.form</field>
+        <field name="model">patrimoine.panne</field>
+        <field name="arch" type="xml">
+            <form string="Signalement de panne">
+                <header>
+                    <field name="state" widget="statusbar" statusbar_visible="draft,to_approve,manager_approved,approved,rejected"/>
+                    <button string="Mes signalements" type="action" name="%(action_panne_my)d"/>
+                </header>
+                <sheet>
+                    <group>
+                        <field name="name" readonly="1"/>
+                        <field name="asset_id" required="1"/>
+                        <field name="date_panne" required="1"/>
+                        <field name="declarer_par_id" readonly="1"/>
+                    </group>
+                    <group>
+                        <field name="description" placeholder="Décrire la panne..." required="1"/>
+                    </group>
+                </sheet>
+                <div class="oe_chatter">
+                    <field name="message_ids" widget="mail_thread"/>
+                </div>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_panne" model="ir.actions.act_window">
+        <field name="name">Signalements de panne</field>
+        <field name="res_model">patrimoine.panne</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
- implement `PatrimoinePanne` model with bus notifications
- register model and add sequence
- create tree/form views and menu entry
- configure security ACLs and rules
- expose REST API endpoints for pannes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b59f213d8832996b51ecde11aae9a