### PR TITLE
Add agent actions page

### DIFF
--- a/patrimoine-mtnd/src/App.jsx
+++ b/patrimoine-mtnd/src/App.jsx
@@ -11,6 +11,7 @@ import SubCategoriesPage from './pages/admin/SubCategoriesPage';
 import AdminAjouterMateriel from './pages/admin/AdminAjouterMateriel';
 import MaterialDetailPage from './pages/admin/MaterialDetailPage';
 import AgentDashboardPage from './pages/agents/AgentDashboardPage';
+import AgentMaterialActionsPage from './pages/agents/AgentMaterialActionsPage';
 import DirDemandeMateriel from './pages/director/DirDemandeMateriel';
 import DirValidationPerte from './pages/director/DirValidationPerte';
 import CategoryItemsPage from './pages/admin/CategoryItemsPage';
@@ -23,6 +24,7 @@ import AdminStatsPage from './pages/admin/AdminStatsPage';
 import AdminCategoriesPage from './pages/admin/AdminCategoriesPage';
 import AdminSubCategoriesPage from './pages/admin/AdminSubCategoriesPage';
 import DeclarationPerte from './pages/DeclarationPerte';
+import DeclarationPanne from './pages/DeclarationPanne';
 import MyDeclarationsPage from './pages/user/MyDeclarationsPage';
 import DirDashboardPage from './pages/director/DirDashboardPage';
 import UnauthorizedPage from './pages/UnauthorizedPage'; // N'oubliez pas l'import
@@ -225,6 +227,23 @@ function AppContent() {
                   }
               />
 
+              <Route
+                  path="/agent/materiel/:id/actions"
+                  element={
+                      <ProtectedRoute
+                          roles={[
+                              ROLES.AGENT,
+                              ROLES.MANAGER,
+                              ROLES.DIRECTOR,
+                              ROLES.ADMIN,
+                              ROLES.ADMIN_INTRANET,
+                          ]}
+                      >
+                          <AgentMaterialActionsPage />
+                      </ProtectedRoute>
+                  }
+              />
+
               {/* --- Route pour les pages générale --- */}
               {/* Tout utilisateur du système de patrimoine peut déclarer une perte */}
               <Route
@@ -240,6 +259,23 @@ function AppContent() {
                           ]}
                       >
                           <DeclarationPerte />
+                      </ProtectedRoute>
+                  }
+              />
+
+              <Route
+                  path="/declaration-pannes"
+                  element={
+                      <ProtectedRoute
+                          roles={[
+                              ROLES.AGENT,
+                              ROLES.MANAGER,
+                              ROLES.DIRECTOR,
+                              ROLES.ADMIN,
+                              ROLES.ADMIN_INTRANET,
+                          ]}
+                      >
+                          <DeclarationPanne />
                       </ProtectedRoute>
                   }
               />

--- a/patrimoine-mtnd/src/pages/DeclarationPanne.jsx
+++ b/patrimoine-mtnd/src/pages/DeclarationPanne.jsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export default function DeclarationPanne() {
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold mb-4">Déclaration de Panne</h1>
+      <p>Formulaire de déclaration de panne à venir.</p>
+    </div>
+  );
+}

--- a/patrimoine-mtnd/src/pages/agents/AgentDashboardPage.jsx
+++ b/patrimoine-mtnd/src/pages/agents/AgentDashboardPage.jsx
@@ -182,7 +182,7 @@ export default function AgentDashboardPage() {
                             key={material.id}
                             className={cardClasses.base}
                             onClick={() =>
-                                navigate(`/admin/materiel/${material.id}`)
+                                navigate(`/agent/materiel/${material.id}/actions`)
                             }
                         >
                             <div className={cardClasses.imageContainer}>

--- a/patrimoine-mtnd/src/pages/agents/AgentMaterialActionsPage.jsx
+++ b/patrimoine-mtnd/src/pages/agents/AgentMaterialActionsPage.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Button } from "@/components/ui/button";
+import { useNavigate } from "react-router-dom";
+
+export default function AgentMaterialActionsPage() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen p-4 sm:p-6 lg:p-8 flex flex-col items-center gap-6">
+      <h1 className="text-2xl font-bold">Actions sur le matériel</h1>
+      <div className="flex flex-col gap-4 w-full max-w-xs">
+        <Button onClick={() => navigate("/declaration-pertes")}>Déclarer une perte</Button>
+        <Button variant="outline" onClick={() => navigate("/declaration-pannes")}>Déclarer une panne</Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add AgentMaterialActionsPage with buttons for losses and breakdowns
- support new actions page in router
- link from AgentDashboardPage to new actions page
- stub DeclarationPanne page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b59f227ac8329af3406430e4e5f0a