### PR TITLE
Support both /agent and /agent/dashboard paths

### DIFF
--- a/patrimoine-mtnd/src/App.jsx
+++ b/patrimoine-mtnd/src/App.jsx
@@ -224,6 +224,23 @@ function AppContent() {
                       </ProtectedRoute>
                   }
               />
+              {/* Permettre l'accès via l'ancien chemin /agent/dashboard */}
+              <Route
+                  path="/agent/dashboard"
+                  element={
+                      <ProtectedRoute
+                          roles={[
+                              ROLES.AGENT,
+                              ROLES.MANAGER,
+                              ROLES.DIRECTOR,
+                              ROLES.ADMIN,
+                              ROLES.ADMIN_INTRANET,
+                          ]}
+                      >
+                          <AgentDashboardPage />
+                      </ProtectedRoute>
+                  }
+              />
 
               {/* --- Route pour les pages générale --- */}
               {/* Tout utilisateur du système de patrimoine peut déclarer une perte */}


### PR DESCRIPTION
## Summary
- add legacy route `/agent/dashboard` so old links still work

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687b59f7276483298ff2b272df55a520