### PR TITLE
Add notification tracking for panne and perte

### DIFF
--- a/controllers/asset_controller.py
+++ b/controllers/asset_controller.py
@@ -2556,6 +2556,23 @@ class PatrimoineAssetController(http.Controller):
             _logger.error("Error processing perte %s: %s", perte_id, str(e))
             return {"status": "error", "message": str(e)}
 
+    @http.route('/api/patrimoine/pertes/<int:perte_id>/views', auth='user', type='http', methods=['POST'], csrf=False)
+    def add_perte_view(self, perte_id, **kw):
+        perte = request.env['patrimoine.perte'].sudo().browse(perte_id)
+        if not perte.exists():
+            return Response(json.dumps({'status': 'error', 'message': 'Perte not found'}), status=404, headers=CORS_HEADERS)
+        perte.write({'viewer_ids': [(4, request.env.user.id)]})
+        return Response(json.dumps({'status': 'success'}), headers=CORS_HEADERS)
+
+    @http.route('/api/patrimoine/pertes/unread_count', auth='user', type='http', methods=['GET'], csrf=False)
+    def pertes_unread_count(self, **kw):
+        count = request.env['patrimoine.perte'].sudo().search_count([
+            ('viewer_ids', 'not in', request.env.user.id),
+            ('manager_id.user_id', '=', request.env.user.id),
+            ('state', '=', 'to_approve'),
+        ])
+        return Response(json.dumps({'status': 'success', 'data': {'count': count}}), headers=CORS_HEADERS)
+
     # --- API pour créer un signalement de panne ---
     @http.route(
         "/api/patrimoine/pannes",
@@ -2712,3 +2729,20 @@ class PatrimoineAssetController(http.Controller):
         except Exception as e:
             _logger.error("Error processing panne %s: %s", panne_id, str(e))
             return {"status": "error", "message": str(e)}
+
+    @http.route('/api/patrimoine/pannes/<int:panne_id>/views', auth='user', type='http', methods=['POST'], csrf=False)
+    def add_panne_view(self, panne_id, **kw):
+        panne = request.env['patrimoine.panne'].sudo().browse(panne_id)
+        if not panne.exists():
+            return Response(json.dumps({'status': 'error', 'message': 'Panne not found'}), status=404, headers=CORS_HEADERS)
+        panne.write({'viewer_ids': [(4, request.env.user.id)]})
+        return Response(json.dumps({'status': 'success'}), headers=CORS_HEADERS)
+
+    @http.route('/api/patrimoine/pannes/unread_count', auth='user', type='http', methods=['GET'], csrf=False)
+    def pannes_unread_count(self, **kw):
+        count = request.env['patrimoine.panne'].sudo().search_count([
+            ('viewer_ids', 'not in', request.env.user.id),
+            ('manager_id.user_id', '=', request.env.user.id),
+            ('state', '=', 'to_approve'),
+        ])
+        return Response(json.dumps({'status': 'success', 'data': {'count': count}}), headers=CORS_HEADERS)

--- a/models/panne.py
+++ b/models/panne.py
@@ -33,6 +33,13 @@ class PatrimoinePanne(models.Model):
     manager_id = fields.Many2one(
         "hr.employee", string="Manager", compute="_compute_manager", store=True
     )
+    viewer_ids = fields.Many2many(
+        "res.users",
+        "panne_view_rel",
+        "panne_id",
+        "user_id",
+        string="Vues",
+    )
     state = fields.Selection(
         [
             ("draft", "Brouillon"),

--- a/tests/test_asset_controller.py
+++ b/tests/test_asset_controller.py
@@ -146,6 +146,42 @@ class AssetControllerTest(unittest.TestCase):
         self.assertEqual(returned['demande_id'], demande_record.id)
 
     @patch('controllers.asset_controller.request')
+    def test_pannes_unread_count(self, mock_request):
+        env = MagicMock()
+        panne_model = MagicMock()
+        env.__getitem__.return_value = panne_model
+        panne_model.sudo.return_value.search_count.return_value = 2
+        mock_request.env = env
+        mock_request.env.user.id = 7
+
+        res = self.controller.pannes_unread_count()
+
+        panne_model.sudo.return_value.search_count.assert_called_with([
+            ('viewer_ids', 'not in', 7),
+            ('manager_id.user_id', '=', 7),
+            ('state', '=', 'to_approve'),
+        ])
+        self.assertIn('application/json', res.headers.get('Content-Type'))
+
+    @patch('controllers.asset_controller.request')
+    def test_pertes_unread_count(self, mock_request):
+        env = MagicMock()
+        perte_model = MagicMock()
+        env.__getitem__.return_value = perte_model
+        perte_model.sudo.return_value.search_count.return_value = 4
+        mock_request.env = env
+        mock_request.env.user.id = 9
+
+        res = self.controller.pertes_unread_count()
+
+        perte_model.sudo.return_value.search_count.assert_called_with([
+            ('viewer_ids', 'not in', 9),
+            ('manager_id.user_id', '=', 9),
+            ('state', '=', 'to_approve'),
+        ])
+        self.assertIn('application/json', res.headers.get('Content-Type'))
+
+    @patch('controllers.asset_controller.request')
     def test_create_demande_json_payload(self, mock_request):
         env = MagicMock()
         demande_model = MagicMock()

--- a/tests/test_panne_perte_notification.py
+++ b/tests/test_panne_perte_notification.py
@@ -1,0 +1,113 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import os
+import sys
+import types
+import importlib.util
+
+# Minimal stub of Odoo
+odoo = types.ModuleType("odoo")
+class BaseModel:
+    @classmethod
+    def create(cls, vals):
+        return []
+odoo.models = types.SimpleNamespace(Model=BaseModel)
+odoo.fields = types.SimpleNamespace(
+    Char=MagicMock(),
+    Many2one=MagicMock(),
+    Text=MagicMock(),
+    Date=MagicMock(),
+    Many2many=MagicMock(),
+    Selection=MagicMock(),
+    Datetime=MagicMock(),
+    Integer=MagicMock(),
+    Boolean=MagicMock(),
+)
+odoo.api = types.SimpleNamespace(
+    model_create_multi=lambda f: f,
+    depends=lambda *a: (lambda f: f),
+    model=lambda f: f,
+)
+odoo._ = lambda x: x
+sys.modules['odoo'] = odoo
+sys.modules['odoo.models'] = odoo.models
+sys.modules['odoo.fields'] = odoo.fields
+sys.modules['odoo.api'] = odoo.api
+odoo.exceptions = types.SimpleNamespace(
+    UserError=type('UserError', (Exception,), {}),
+    AccessError=type('AccessError', (Exception,), {}),
+    ValidationError=type('ValidationError', (Exception,), {}),
+)
+ex_mod = sys.modules.setdefault('odoo.exceptions', odoo.exceptions)
+for attr in ['UserError', 'AccessError', 'ValidationError']:
+    if not hasattr(ex_mod, attr):
+        setattr(ex_mod, attr, getattr(odoo.exceptions, attr))
+
+# Load panne model
+panne_path = os.path.join(os.path.dirname(__file__), '..', 'models', 'panne.py')
+spec_panne = importlib.util.spec_from_file_location('models.panne', panne_path)
+panne = importlib.util.module_from_spec(spec_panne)
+spec_panne.loader.exec_module(panne)
+sys.modules['models.panne'] = panne
+
+# Load perte model
+perte_path = os.path.join(os.path.dirname(__file__), '..', 'models', 'pertes.py')
+spec_perte = importlib.util.spec_from_file_location('models.pertes', perte_path)
+perte = importlib.util.module_from_spec(spec_perte)
+spec_perte.loader.exec_module(perte)
+sys.modules['models.pertes'] = perte
+
+models_pkg = types.ModuleType('models')
+models_pkg.panne = panne
+models_pkg.pertes = perte
+panne.models = types.SimpleNamespace(Model=odoo.models.Model)
+perte.models = types.SimpleNamespace(Model=odoo.models.Model)
+sys.modules.setdefault('models', models_pkg)
+
+class PannePerteNotificationTest(unittest.TestCase):
+    def test_panne_create_notifies_manager(self):
+        fake_env = MagicMock()
+        fake_bus = MagicMock()
+        fake_env.__getitem__.return_value = fake_bus
+        fake_record = MagicMock()
+        fake_record.id = 1
+        fake_record.asset_id.name = 'A'
+        fake_record.description = 'desc'
+        fake_record.manager_id.user_id.partner_id = MagicMock()
+        FakeSelf = type('FakeSelf', (panne.PatrimoinePanne,), {})
+        fake_self = FakeSelf()
+        fake_self.env = fake_env
+        fake_self._cr = MagicMock(dbname='x')
+        with patch('models.panne.models.Model.create', return_value=fake_record):
+            panne.PatrimoinePanne.create(fake_self, {'asset_id': 1})
+        fake_bus.sendmany.assert_called_once()
+        args, _ = fake_bus.sendmany.call_args
+        self.assertEqual(args[0][0][1]['type'], 'new_panne')
+
+    def test_perte_create_notifies_manager_and_director(self):
+        fake_env = MagicMock()
+        fake_bus = MagicMock()
+        fake_env.__getitem__.return_value = fake_bus
+        fake_record = MagicMock()
+        fake_record.id = 2
+        fake_record.asset_id.name = 'B'
+        fake_record.motif = 'm'
+        fake_record.manager_id.user_id.partner_id = MagicMock()
+        dept_partner = MagicMock()
+        fake_employee = MagicMock()
+        fake_employee.department_id.manager_id.user_id.partner_id = dept_partner
+        fake_employees = MagicMock()
+        fake_employees.__getitem__.return_value = fake_employee
+        fake_record.declarer_par_id.employee_ids = fake_employees
+        FakeSelf = type('FakeSelf', (perte.PatrimoinePerte,), {})
+        fake_self = FakeSelf()
+        fake_self.env = fake_env
+        fake_self._cr = MagicMock(dbname='y')
+        with patch('models.pertes.models.Model.create', return_value=fake_record):
+            perte.PatrimoinePerte.create(fake_self, {'asset_id': 1})
+        fake_bus.sendmany.assert_called_once()
+        args, _ = fake_bus.sendmany.call_args
+        self.assertEqual(args[0][0][1]['type'], 'new_perte')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- notify department director when a loss declaration is created
- track seen users for pannes and pertes
- expose endpoints to mark declarations as viewed and return unread counts
- test notification logic for panne/perte models
- test unread count APIs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b628d75dc83299486f4d82093ace4