### PR TITLE
Fix post-init hook call in module

### DIFF
--- a/hooks.py
+++ b/hooks.py
@@ -35,8 +35,7 @@ def pre_init_hook(cr):
     # If not found, data loading will create the group normally
 
 
-def post_init_hook(cr, registry):
+def post_init_hook(env):
     """Ensure XML ID exists when upgrading the module."""
-    env = api.Environment(cr, SUPERUSER_ID, {})
     _link_admin_group(env)
 


### PR DESCRIPTION
## Summary
- adjust `post_init_hook` signature for Odoo 17

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b9a9e491c8329bd1aa40f204f1381