### PR TITLE
fix: add default export to categoryService

### DIFF
--- a/patrimoine-mtnd/src/services/categoryService.js
+++ b/patrimoine-mtnd/src/services/categoryService.js
@@ -25,7 +25,18 @@ export const updateSubCategory = (categoryId, subcategoryId, subcategoryData) =>
 export const deleteCategory = (categoryId) => 
   del(`/patrimoine/categories/${categoryId}`)
 
-export const deleteSubCategory = (categoryId, subcategoryId) => 
+export const deleteSubCategory = (categoryId, subcategoryId) =>
   del(`/patrimoine/categories/${categoryId}/subcategories/${subcategoryId}`)
 
 // Suppression des fonctions redondantes avec materialService.js
+
+export default {
+  getCategories,
+  getSubCategories,
+  createCategory,
+  createSubCategory,
+  updateCategory,
+  updateSubCategory,
+  deleteCategory,
+  deleteSubCategory
+};


### PR DESCRIPTION
## Summary
- expose a default export for category service functions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687bb143794c83298ad420404e40c8d4