### PR TITLE
Fix dev proxy and bus hook

### DIFF
--- a/patrimoine-mtnd/src/hooks/useOdooBus.js
+++ b/patrimoine-mtnd/src/hooks/useOdooBus.js
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import axios from 'axios'
+import api from '@/services/apiConfig'
 
 export default function useOdooBus(onNotification) {
   useEffect(() => {
@@ -8,7 +8,7 @@ export default function useOdooBus(onNotification) {
 
     const poll = async () => {
       try {
-        const response = await axios.post('/longpolling/poll', {
+        const response = await api.post('/longpolling/poll', {
           channels: [['mail.channel', 'private', 0]],
           last,
           timeout: 50,

--- a/patrimoine-mtnd/vite.config.js
+++ b/patrimoine-mtnd/vite.config.js
@@ -17,6 +17,29 @@ export default defineConfig({
         host: "0.0.0.0",
         port: 5174,
         strictPort: true,
+        proxy: {
+            "/api": {
+                target: "http://localhost:8069",
+                changeOrigin: true,
+                secure: false,
+            },
+            "/web": {
+                target: "http://localhost:8069",
+                changeOrigin: true,
+                secure: false,
+            },
+            "/websocket": {
+                target: "ws://localhost:8069",
+                ws: true,
+                changeOrigin: true,
+                secure: false,
+            },
+            "/longpolling": {
+                target: "http://localhost:8072",
+                changeOrigin: true,
+                secure: false,
+            },
+        },
     },
     build: {
         outDir: "dist",


### PR DESCRIPTION
## Summary
- configure Vite dev proxy so `/longpolling`, `/api`, `/web` and websocket paths forward to Odoo
- use the preconfigured axios instance in `useOdooBus` so requests hit the backend

## Testing
- `pytest -q`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bbe46416c8329bbf67ce7d0638d15