### PR TITLE
Fix CORS headers for cross‑origin requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ If you see the error "Couldn't bind the websocket," make sure the Odoo server is
 When the frontend and backend run on different origins, set the environment
 variable `ALLOWED_ORIGIN` on the Odoo server to the URL of your frontend
 (for example `http://localhost:5174`). The controllers automatically add the
-appropriate CORS headers based on this value so browsers allow requests that
-include credentials.
+`Access-Control-Allow-Origin` and related headers based on this value so
+browsers allow requests that include credentials.
 
 ## Running the tests
 

--- a/controllers/common.py
+++ b/controllers/common.py
@@ -4,6 +4,7 @@ import os
 from functools import wraps
 from odoo.exceptions import AccessError, ValidationError
 from odoo.http import Response as OdooResponse
+from odoo import http
 
 # Allow overriding the CORS origin via an environment variable so deployments
 # can specify their frontend URL.  Using a specific origin is required when the
@@ -12,6 +13,10 @@ ALLOWED_ORIGIN = os.environ.get("ALLOWED_ORIGIN", "http://localhost:5174")
 
 CORS_HEADERS = {
     "Content-Type": "application/json",
+    "Access-Control-Allow-Origin": ALLOWED_ORIGIN,
+    "Access-Control-Allow-Credentials": "true",
+    "Access-Control-Allow-Headers": "Content-Type, X-Requested-With, X-Openerp-Session-Id",
+    "Access-Control-Allow-Methods": "GET,POST,PUT,DELETE,OPTIONS",
 }
 
 
@@ -58,3 +63,13 @@ def handle_api_errors(func):
             )
 
     return wrapper
+
+
+class CORSController(http.Controller):
+    """Generic controller to respond to CORS preflight requests."""
+
+    @http.route('/<path:any>', type='http', auth='none', methods=['OPTIONS'], csrf=False)
+    def options(self, **_):
+        """Return an empty response with CORS headers for preflight."""
+        return Response(status=200)
+


### PR DESCRIPTION
## Summary
- add proper CORS headers in controllers
- handle OPTIONS requests so browsers can preflight
- clarify README about the `ALLOWED_ORIGIN` behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c0e25654883299141921cec63ace8