### PR TITLE
Add motion animations to dashboards

### DIFF
--- a/patrimoine-mtnd/package.json
+++ b/patrimoine-mtnd/package.json
@@ -38,7 +38,8 @@
     "recharts": "^2.15.3",
     "sonner": "^2.0.5",
     "tailwind-merge": "^3.3.0",
-    "zustand": "^4.4.6"
+    "zustand": "^4.4.6",
+    "framer-motion": "^10.16.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.56",

--- a/patrimoine-mtnd/src/components/ui/stat-card.tsx
+++ b/patrimoine-mtnd/src/components/ui/stat-card.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useEffect, useState } from "react"
 import { cn } from "@/lib/utils"
 import { ArrowUp, ArrowDown } from "lucide-react"
 
@@ -11,19 +11,41 @@ interface StatCardProps {
   className?: string
 }
 
-export function StatCard({ 
-  title, 
-  value, 
-  icon, 
-  trend, 
-  description, 
-  className 
+export function StatCard({
+  title,
+  value,
+  icon,
+  trend,
+  description,
+  className
 }: StatCardProps) {
+  const [displayValue, setDisplayValue] = useState(
+    typeof value === 'number' ? 0 : value
+  )
   const trendColor = {
     up: 'text-green-500',
     down: 'text-red-500',
     neutral: 'text-gray-500'
   }
+
+  useEffect(() => {
+    if (typeof value !== 'number') {
+      setDisplayValue(value)
+      return
+    }
+    let frame: number
+    const duration = 1000
+    const start = performance.now()
+    const animate = (now: number) => {
+      const progress = Math.min((now - start) / duration, 1)
+      setDisplayValue(Math.floor(progress * value))
+      if (progress < 1) {
+        frame = requestAnimationFrame(animate)
+      }
+    }
+    frame = requestAnimationFrame(animate)
+    return () => cancelAnimationFrame(frame)
+  }, [value])
 
   return (
     <div className={cn(
@@ -33,7 +55,7 @@ export function StatCard({
       <div className="flex justify-between">
         <div>
           <p className="text-sm text-white">{title}</p>
-          <p className="text-2xl font-bold mt-1">{value}</p>
+          <p className="text-2xl font-bold mt-1">{displayValue}</p>
           {description && <p className="text-xs text-gray-400 mt-1">{description}</p>}
         </div>
         {icon && (

--- a/patrimoine-mtnd/src/pages/agents/AgentDashboardPage.jsx
+++ b/patrimoine-mtnd/src/pages/agents/AgentDashboardPage.jsx
@@ -6,6 +6,7 @@ import materialService from "@/services/materialService"
 import { useAuth } from "@/context/AuthContext"
 import { StatCard } from "@/components/ui/stat-card"
 import { Input } from "@/components/ui/input"
+import { motion } from "framer-motion"
 import {
     Search,
     Package,
@@ -38,6 +39,19 @@ const cardClasses = {
   statusBar: "flex justify-between items-center gap-2",
   typeBadge: "text-white text-sm font-medium bg-indigo-600/90 px-3 py-1 rounded-full backdrop-blur-sm",
   statusBadge: "text-white text-sm font-medium px-3 py-1 rounded-full backdrop-blur-sm"
+}
+
+const containerVariants = {
+  hidden: { opacity: 0 },
+  show: {
+    opacity: 1,
+    transition: { staggerChildren: 0.1 }
+  }
+}
+
+const itemVariants = {
+  hidden: { opacity: 0, y: 20 },
+  show: { opacity: 1, y: 0 }
 }
 
 export default function AgentDashboardPage() {
@@ -175,10 +189,16 @@ export default function AgentDashboardPage() {
               </div>
             </div>
 
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+            <motion.div
+              variants={containerVariants}
+              initial="hidden"
+              animate="show"
+              className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6"
+            >
                 {filteredMaterials.length > 0 ? (
                     filteredMaterials.map(material => (
-                        <div
+                        <motion.div
+                            variants={itemVariants}
                             key={material.id}
                             className={cardClasses.base}
                             onClick={() =>
@@ -228,7 +248,7 @@ export default function AgentDashboardPage() {
                                 </span>
                               </div>
                             </div>
-                        </div>
+                        </motion.div>
                     ))
                 ) : (
                     <div className="col-span-full">
@@ -246,7 +266,7 @@ export default function AgentDashboardPage() {
                         </Card>
                     </div>
                 )}
-            </div>
+            </motion.div>
         </div>
     )
 }

--- a/patrimoine-mtnd/src/pages/director/DirDashboardPage.jsx
+++ b/patrimoine-mtnd/src/pages/director/DirDashboardPage.jsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { API_BASE_URL } from "@/config/api"
+import { motion } from "framer-motion"
 import {
     Search,
     PlusCircle,
@@ -28,6 +29,19 @@ const cardClasses = {
     statusBar: "flex justify-between items-center gap-2",
     typeBadge: "text-white text-sm font-medium bg-indigo-600/90 px-3 py-1 rounded-full backdrop-blur-sm",
     statusBadge: "text-white text-sm font-medium px-3 py-1 rounded-full backdrop-blur-sm",
+}
+
+const containerVariants = {
+    hidden: { opacity: 0 },
+    show: {
+        opacity: 1,
+        transition: { staggerChildren: 0.1 }
+    }
+}
+
+const itemVariants = {
+    hidden: { opacity: 0, y: 20 },
+    show: { opacity: 1, y: 0 }
 }
 
 const getStatusColor = status => {
@@ -191,10 +205,16 @@ export default function DirDashboardPage() {
                 </Button>
             </div>
 
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8">
+            <motion.div
+                variants={containerVariants}
+                initial="hidden"
+                animate="show"
+                className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8"
+            >
                 {filteredMaterials.length > 0 ? (
                     filteredMaterials.map(material => (
-                        <div
+                        <motion.div
+                            variants={itemVariants}
                             key={material.id}
                             className={cardClasses.base}
                             onClick={() => handleMaterialClick(material.id)}
@@ -247,7 +267,7 @@ export default function DirDashboardPage() {
                                     </span>
                                 </div>
                             </div>
-                        </div>
+                        </motion.div>
                     ))
                 ) : (
                     <div className="col-span-full">
@@ -265,7 +285,7 @@ export default function DirDashboardPage() {
                         </Card>
                     </div>
                 )}
-            </div>
+            </motion.div>
         </div>
     )
 }


### PR DESCRIPTION
## Summary
- animate stat card values on mount
- stagger material cards using framer motion
- update dashboards to fade/slide cards in
- declare framer-motion dependency

## Testing
- `pytest -q`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687c412c35f083299d7e47b9f2796417